### PR TITLE
chore: add DCO and update README with contributing guidelines

### DIFF
--- a/DCO
+++ b/DCO
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/README.md
+++ b/README.md
@@ -50,13 +50,44 @@ Both implementations fulfill the same [CAPI provider contract](https://cluster-a
 
 ## Development
 
+See [DEVELOPMENT.md](DEVELOPMENT.md) for full setup instructions.
+
 ```bash
 # Python
 cd python && uv sync && uv run pytest
 
 # Rust
 cd rust && cargo test
+
+# Apply CRDs
+kubectl apply -k shared/crds/
 ```
+
+## Contributing
+
+We welcome contributions! By contributing to this project, you agree to the [Developer Certificate of Origin (DCO)](DCO).
+
+All commits must be signed off to certify that you wrote or have the right to submit the code:
+
+```bash
+git commit -s -m "feat: add my contribution"
+```
+
+This adds a `Signed-off-by` trailer to your commit message. If you forget, amend the commit:
+
+```bash
+git commit --amend -s
+```
+
+### Branch rules
+
+- `main` and `develop` are protected -- all changes require a pull request
+- Branch naming: `<type>/<short-description>` (e.g. `feat/add-ssh-key-rotation`)
+- Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+
+## License
+
+This project is licensed under the [Mozilla Public License 2.0](LICENSE).
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Add Developer Certificate of Origin (DCO) file for contributor sign-off
- Update README with Contributing section (sign-off instructions, branch rules)
- Add License section linking to MPL-2.0
- Link to DEVELOPMENT.md for setup details

## Test plan

- [x] DCO file matches Linux Foundation standard text
- [x] README rendering verified
- [x] Branch protection ruleset active on main + develop