### PR TITLE
fix(python): enable kopf liveness endpoint for probes

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -19,4 +19,4 @@ RUN groupadd --gid 65532 nonroot && \
     useradd --uid 65532 --gid 65532 --no-create-home nonroot
 USER 65532:65532
 
-ENTRYPOINT ["uv", "run", "kopf", "run", "--standalone", "src/capi_provider_ssh/main.py"]
+ENTRYPOINT ["uv", "run", "kopf", "run", "--standalone", "--liveness=http://0.0.0.0:8080/healthz", "src/capi_provider_ssh/main.py"]


### PR DESCRIPTION
## Summary

- add Kopf --liveness endpoint to container entrypoint
- bind liveness server on 0.0.0.0:8080
- align runtime behavior with existing /healthz probes in deployment 

## Validation

- inspected Dockerfile/deployment probe alignment
- no code-path changes outside runtime startup flags