### PR TITLE
test(python): add unit tests for all controllers and SSH client

### DIFF
--- a/python/src/capi_provider_ssh/controllers/sshmachine.py
+++ b/python/src/capi_provider_ssh/controllers/sshmachine.py
@@ -196,7 +196,7 @@ async def sshmachine_reconcile(spec, status, name, namespace, meta, patch, **_kw
 
     # SSH bootstrap
     try:
-        async with SSHClient.connect(address=address, port=port, user=user, key=ssh_key) as conn:
+        async with await SSHClient.connect(address=address, port=port, user=user, key=ssh_key) as conn:
             # Upload bootstrap script
             await conn.upload(bootstrap_data, "/tmp/bootstrap.sh")  # noqa: S108
 
@@ -270,7 +270,7 @@ async def sshmachine_delete(spec, name, namespace, **_kwargs):
         return
 
     try:
-        async with SSHClient.connect(address=address, port=port, user=user, key=ssh_key) as conn:
+        async with await SSHClient.connect(address=address, port=port, user=user, key=ssh_key) as conn:
             cleanup_cmd = "kubeadm reset -f && rm -rf /etc/kubernetes /var/lib/kubelet"
             result = await conn.execute(cleanup_cmd)
             if result.success:

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,1 +1,64 @@
 """Shared test fixtures for capi-provider-ssh."""
+
+import pytest
+
+
+@pytest.fixture
+def sshcluster_spec():
+    """Minimal SSHCluster spec."""
+    return {
+        "controlPlaneEndpoint": {
+            "host": "10.0.0.1",
+            "port": 6443,
+        },
+    }
+
+
+@pytest.fixture
+def sshcluster_meta_with_owner():
+    """SSHCluster metadata with CAPI Cluster ownerReference."""
+    return {
+        "ownerReferences": [
+            {
+                "apiVersion": "cluster.x-k8s.io/v1beta1",
+                "kind": "Cluster",
+                "name": "test-cluster",
+                "uid": "abc-123",
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def sshcluster_meta_no_owner():
+    """SSHCluster metadata without ownerReference."""
+    return {}
+
+
+@pytest.fixture
+def sshmachine_spec():
+    """Minimal SSHMachine spec."""
+    return {
+        "address": "100.64.0.10",
+        "port": 22,
+        "user": "root",
+        "sshKeyRef": {
+            "name": "ssh-key-secret",
+            "key": "value",
+        },
+    }
+
+
+@pytest.fixture
+def sshmachine_meta_with_owner():
+    """SSHMachine metadata with CAPI Machine ownerReference."""
+    return {
+        "ownerReferences": [
+            {
+                "apiVersion": "cluster.x-k8s.io/v1beta1",
+                "kind": "Machine",
+                "name": "test-machine-0",
+                "uid": "def-456",
+            }
+        ]
+    }

--- a/python/tests/test_ssh.py
+++ b/python/tests/test_ssh.py
@@ -1,0 +1,55 @@
+"""Tests for SSH client wrapper."""
+
+import pytest
+
+from capi_provider_ssh.ssh import SSHResult, _redact
+
+
+class TestSSHResult:
+    def test_success_true(self):
+        r = SSHResult(exit_code=0, stdout="ok", stderr="")
+        assert r.success is True
+
+    def test_success_false(self):
+        r = SSHResult(exit_code=1, stdout="", stderr="error")
+        assert r.success is False
+
+    def test_frozen(self):
+        r = SSHResult(exit_code=0, stdout="", stderr="")
+        with pytest.raises(AttributeError):
+            r.exit_code = 1  # type: ignore[misc]
+
+
+class TestRedact:
+    def test_redacts_token(self):
+        text = "--token abcdef.1234567890abcdef"
+        assert "[REDACTED]" in _redact(text)
+
+    def test_redacts_certificate_key(self):
+        text = "--certificate-key abc123def456"
+        assert "[REDACTED]" in _redact(text)
+
+    def test_redacts_discovery_token_ca_cert_hash(self):
+        text = "--discovery-token-ca-cert-hash sha256:abc123"
+        assert "[REDACTED]" in _redact(text)
+
+    def test_preserves_safe_lines(self):
+        text = "kubeadm join 10.0.0.1:6443"
+        assert _redact(text) == text
+
+    def test_multiline_selective_redaction(self):
+        text = "line1\n--token abc123\nline3"
+        result = _redact(text)
+        assert result.startswith("line1\n")
+        assert result.endswith("\nline3")
+        assert "[REDACTED]" in result
+
+    def test_private_key_not_logged(self):
+        """Verify private key material is never in log-safe output."""
+        # The SSH client never logs key material directly,
+        # but verify the redact function handles it
+        text = "-----BEGIN OPENSSH PRIVATE KEY-----\nbase64data\n-----END OPENSSH PRIVATE KEY-----"
+        # Keys don't match token patterns, but they should never
+        # appear in logs anyway (the SSH client doesn't log keys)
+        result = _redact(text)
+        assert result is not None  # Just verify it doesn't crash

--- a/python/tests/test_sshcluster.py
+++ b/python/tests/test_sshcluster.py
@@ -1,0 +1,70 @@
+"""Tests for SSHCluster controller."""
+
+import kopf
+
+from capi_provider_ssh.controllers.sshcluster import (
+    _has_capi_cluster_owner,
+    _reconcile,
+)
+
+
+class TestHasCapiClusterOwner:
+    def test_with_cluster_owner(self, sshcluster_meta_with_owner):
+        assert _has_capi_cluster_owner(sshcluster_meta_with_owner["ownerReferences"]) is True
+
+    def test_without_owner(self):
+        assert _has_capi_cluster_owner(None) is False
+
+    def test_empty_list(self):
+        assert _has_capi_cluster_owner([]) is False
+
+    def test_wrong_kind(self):
+        refs = [{"apiVersion": "cluster.x-k8s.io/v1beta1", "kind": "Machine", "name": "m"}]
+        assert _has_capi_cluster_owner(refs) is False
+
+    def test_wrong_api_group(self):
+        refs = [{"apiVersion": "apps/v1", "kind": "Cluster", "name": "c"}]
+        assert _has_capi_cluster_owner(refs) is False
+
+
+class TestSSHClusterReconcile:
+    def test_paused_skips_reconciliation(self, sshcluster_meta_with_owner):
+        spec = {"controlPlaneEndpoint": {"host": "10.0.0.1", "port": 6443}, "paused": True}
+        patch = kopf.Patch({})
+        _reconcile(spec, "test", "default", sshcluster_meta_with_owner, patch)
+        # Should not set any status when paused
+        assert "status" not in patch or "initialization" not in patch.get("status", {})
+
+    def test_no_owner_not_ready(self, sshcluster_spec, sshcluster_meta_no_owner):
+        patch = kopf.Patch({})
+        _reconcile(sshcluster_spec, "test", "default", sshcluster_meta_no_owner, patch)
+        assert patch["status"]["initialization"]["provisioned"] is False
+        assert patch["status"]["conditions"][0]["reason"] == "WaitingForClusterOwner"
+
+    def test_valid_cluster_provisioned(self, sshcluster_spec, sshcluster_meta_with_owner):
+        patch = kopf.Patch({})
+        _reconcile(sshcluster_spec, "test", "default", sshcluster_meta_with_owner, patch)
+        assert patch["status"]["initialization"]["provisioned"] is True
+        assert patch["status"]["conditions"][0]["status"] == "True"
+        assert patch["status"]["conditions"][0]["reason"] == "Provisioned"
+
+    def test_invalid_endpoint_not_ready(self, sshcluster_meta_with_owner):
+        spec = {"controlPlaneEndpoint": {"host": "", "port": 0}}
+        patch = kopf.Patch({})
+        _reconcile(spec, "test", "default", sshcluster_meta_with_owner, patch)
+        assert patch["status"]["initialization"]["provisioned"] is False
+        assert patch["status"]["conditions"][0]["reason"] == "InvalidEndpoint"
+
+    def test_idempotent_reconciliation(self, sshcluster_spec, sshcluster_meta_with_owner):
+        """Running reconcile twice produces same result."""
+        patch1 = kopf.Patch({})
+        patch2 = kopf.Patch({})
+        _reconcile(sshcluster_spec, "test", "default", sshcluster_meta_with_owner, patch1)
+        _reconcile(sshcluster_spec, "test", "default", sshcluster_meta_with_owner, patch2)
+        assert patch1["status"]["initialization"] == patch2["status"]["initialization"]
+
+    def test_condition_has_timestamp(self, sshcluster_spec, sshcluster_meta_with_owner):
+        patch = kopf.Patch({})
+        _reconcile(sshcluster_spec, "test", "default", sshcluster_meta_with_owner, patch)
+        condition = patch["status"]["conditions"][0]
+        assert "lastTransitionTime" in condition

--- a/python/tests/test_sshmachine.py
+++ b/python/tests/test_sshmachine.py
@@ -1,0 +1,232 @@
+"""Tests for SSHMachine controller."""
+
+from unittest.mock import AsyncMock, patch
+
+import kopf
+import pytest
+
+from capi_provider_ssh.controllers.sshmachine import (
+    _has_machine_owner,
+    _is_already_provisioned,
+    sshmachine_delete,
+    sshmachine_reconcile,
+)
+from capi_provider_ssh.ssh import SSHResult
+
+
+class TestHasMachineOwner:
+    def test_with_machine_owner(self, sshmachine_meta_with_owner):
+        assert _has_machine_owner(sshmachine_meta_with_owner["ownerReferences"]) is True
+
+    def test_without_owner(self):
+        assert _has_machine_owner(None) is False
+
+    def test_wrong_kind(self):
+        refs = [{"apiVersion": "cluster.x-k8s.io/v1beta1", "kind": "Cluster", "name": "c"}]
+        assert _has_machine_owner(refs) is False
+
+
+class TestIsAlreadyProvisioned:
+    def test_provisioned_with_ready(self):
+        status = {
+            "initialization": {"provisioned": True},
+            "conditions": [{"type": "Ready", "status": "True"}],
+        }
+        assert _is_already_provisioned(status, "ssh://10.0.0.1") is True
+
+    def test_not_provisioned(self):
+        assert _is_already_provisioned({}, "ssh://10.0.0.1") is False
+
+    def test_provisioned_but_not_ready(self):
+        status = {
+            "initialization": {"provisioned": True},
+            "conditions": [{"type": "Ready", "status": "False"}],
+        }
+        assert _is_already_provisioned(status, "ssh://10.0.0.1") is False
+
+
+class TestSSHMachineReconcile:
+    @pytest.mark.asyncio
+    async def test_paused_skips(self, sshmachine_meta_with_owner):
+        spec = {**{"address": "10.0.0.1"}, "paused": True}
+        patch_obj = kopf.Patch({})
+        await sshmachine_reconcile(
+            spec=spec, status={}, name="m1", namespace="default",
+            meta=sshmachine_meta_with_owner, patch=patch_obj,
+        )
+        assert "initialization" not in patch_obj.get("status", {})
+
+    @pytest.mark.asyncio
+    async def test_no_owner_not_ready(self, sshmachine_spec):
+        patch_obj = kopf.Patch({})
+        await sshmachine_reconcile(
+            spec=sshmachine_spec, status={}, name="m1", namespace="default",
+            meta={}, patch=patch_obj,
+        )
+        assert patch_obj["status"]["initialization"]["provisioned"] is False
+        assert patch_obj["status"]["conditions"][0]["reason"] == "WaitingForMachineOwner"
+
+    @pytest.mark.asyncio
+    async def test_already_provisioned_skips(self, sshmachine_spec, sshmachine_meta_with_owner):
+        status = {
+            "initialization": {"provisioned": True},
+            "conditions": [{"type": "Ready", "status": "True"}],
+        }
+        patch_obj = kopf.Patch({})
+        await sshmachine_reconcile(
+            spec=sshmachine_spec, status=status, name="m1", namespace="default",
+            meta=sshmachine_meta_with_owner, patch=patch_obj,
+        )
+        # Should not modify status (idempotent)
+        assert "initialization" not in patch_obj.get("status", {})
+
+    @pytest.mark.asyncio
+    async def test_waiting_for_bootstrap_data(self, sshmachine_spec, sshmachine_meta_with_owner):
+        with patch(
+            "capi_provider_ssh.controllers.sshmachine._read_bootstrap_data",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            patch_obj = kopf.Patch({})
+            with pytest.raises(kopf.TemporaryError, match="Bootstrap data not ready"):
+                await sshmachine_reconcile(
+                    spec=sshmachine_spec, status={}, name="m1", namespace="default",
+                    meta=sshmachine_meta_with_owner, patch=patch_obj,
+                )
+
+    @pytest.mark.asyncio
+    async def test_missing_ssh_key_ref(self, sshmachine_meta_with_owner):
+        spec = {"address": "10.0.0.1"}  # No sshKeyRef
+        with patch(
+            "capi_provider_ssh.controllers.sshmachine._read_bootstrap_data",
+            new_callable=AsyncMock,
+            return_value="#!/bin/bash\nkubeadm join ...",
+        ):
+            patch_obj = kopf.Patch({})
+            with pytest.raises(kopf.PermanentError, match="sshKeyRef.name"):
+                await sshmachine_reconcile(
+                    spec=spec, status={}, name="m1", namespace="default",
+                    meta=sshmachine_meta_with_owner, patch=patch_obj,
+                )
+
+    @pytest.mark.asyncio
+    async def test_successful_bootstrap(self, sshmachine_spec, sshmachine_meta_with_owner):
+        """Regression: SSHClient.connect() is async, so the controller must use
+        ``async with await SSHClient.connect(...)`` (not ``async with SSHClient.connect(...)``).
+        Without the ``await``, the coroutine is passed directly to ``__aenter__`` which fails
+        with "'coroutine' object does not support the asynchronous context manager protocol".
+        """
+        mock_conn = AsyncMock()
+        mock_conn.execute.return_value = SSHResult(exit_code=0, stdout="ok", stderr="")
+        mock_conn.upload = AsyncMock()
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "capi_provider_ssh.controllers.sshmachine._read_bootstrap_data",
+                new_callable=AsyncMock,
+                return_value="#!/bin/bash\nkubeadm join ...",
+            ),
+            patch(
+                "capi_provider_ssh.controllers.sshmachine._read_ssh_key",
+                new_callable=AsyncMock,
+                return_value="-----BEGIN OPENSSH PRIVATE KEY-----\nfake\n-----END OPENSSH PRIVATE KEY-----",
+            ),
+            patch(
+                "capi_provider_ssh.controllers.sshmachine.SSHClient.connect",
+                new_callable=AsyncMock,
+                return_value=mock_conn,
+            ),
+        ):
+            patch_obj = kopf.Patch({})
+            await sshmachine_reconcile(
+                spec=sshmachine_spec, status={}, name="m1", namespace="default",
+                meta=sshmachine_meta_with_owner, patch=patch_obj,
+            )
+            assert patch_obj["status"]["initialization"]["provisioned"] is True
+            assert patch_obj["spec"]["providerID"] == "ssh://100.64.0.10"
+            assert patch_obj["status"]["addresses"][0]["address"] == "100.64.0.10"
+            assert patch_obj["status"]["failureReason"] is None
+
+    @pytest.mark.asyncio
+    async def test_bootstrap_failure_sets_failure_status(self, sshmachine_spec, sshmachine_meta_with_owner):
+        mock_conn = AsyncMock()
+        mock_conn.execute.return_value = SSHResult(exit_code=1, stdout="", stderr="error")
+        mock_conn.upload = AsyncMock()
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "capi_provider_ssh.controllers.sshmachine._read_bootstrap_data",
+                new_callable=AsyncMock,
+                return_value="#!/bin/bash\nkubeadm join ...",
+            ),
+            patch(
+                "capi_provider_ssh.controllers.sshmachine._read_ssh_key",
+                new_callable=AsyncMock,
+                return_value="fake-key",
+            ),
+            patch(
+                "capi_provider_ssh.controllers.sshmachine.SSHClient.connect",
+                new_callable=AsyncMock,
+                return_value=mock_conn,
+            ),
+        ):
+            patch_obj = kopf.Patch({})
+            with pytest.raises(kopf.TemporaryError, match="Bootstrap failed"):
+                await sshmachine_reconcile(
+                    spec=sshmachine_spec, status={}, name="m1", namespace="default",
+                    meta=sshmachine_meta_with_owner, patch=patch_obj,
+                )
+            assert patch_obj["status"]["failureReason"] == "BootstrapFailed"
+
+
+class TestSSHMachineDelete:
+    @pytest.mark.asyncio
+    async def test_delete_no_address_skips(self):
+        """Missing address should not block finalizer."""
+        await sshmachine_delete(spec={}, name="m1", namespace="default")
+
+    @pytest.mark.asyncio
+    async def test_delete_runs_kubeadm_reset(self, sshmachine_spec):
+        mock_conn = AsyncMock()
+        mock_conn.execute.return_value = SSHResult(exit_code=0, stdout="ok", stderr="")
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "capi_provider_ssh.controllers.sshmachine._read_ssh_key",
+                new_callable=AsyncMock,
+                return_value="fake-key",
+            ),
+            patch(
+                "capi_provider_ssh.controllers.sshmachine.SSHClient.connect",
+                new_callable=AsyncMock,
+                return_value=mock_conn,
+            ),
+        ):
+            await sshmachine_delete(spec=sshmachine_spec, name="m1", namespace="default")
+            mock_conn.execute.assert_called_once()
+            cmd = mock_conn.execute.call_args[0][0]
+            assert "kubeadm reset -f" in cmd
+
+    @pytest.mark.asyncio
+    async def test_delete_ssh_failure_does_not_raise(self, sshmachine_spec):
+        """SSH cleanup failure must not block finalizer removal."""
+        with (
+            patch(
+                "capi_provider_ssh.controllers.sshmachine._read_ssh_key",
+                new_callable=AsyncMock,
+                return_value="fake-key",
+            ),
+            patch(
+                "capi_provider_ssh.controllers.sshmachine.SSHClient.connect",
+                new_callable=AsyncMock,
+                side_effect=ConnectionRefusedError("refused"),
+            ),
+        ):
+            # Should not raise
+            await sshmachine_delete(spec=sshmachine_spec, name="m1", namespace="default")


### PR DESCRIPTION
## Summary

- 36 pytest tests covering all Python modules
- SSHCluster controller: owner check, pause, endpoint validation, idempotency
- SSHMachine controller: full bootstrap flow, failure classification, delete cleanup
- SSH client: SSHResult dataclass, log redaction patterns
- **Bug fix**: `async with await SSHClient.connect()` (was missing `await`, causing context manager protocol error)
- Regression test with docstring explaining the root cause

Closes #5

## Test plan

- [x] `uv venv --clear && uv sync && uv run pytest -v` -- 36/36 passing
- [x] `uv run ruff check .` -- all clean
- [x] Coverage: 64% (realistic for unit tests without real SSH/K8s)