### PR TITLE
fix(python): harden runtime startup, remove uv run from ENTRYPOINT

### DIFF
--- a/python/tests/test_runtime_regression.py
+++ b/python/tests/test_runtime_regression.py
@@ -6,23 +6,30 @@ DOCKERFILE = Path(__file__).resolve().parents[1] / "Dockerfile"
 
 
 def test_docker_entrypoint_uses_kopf_directly() -> None:
+    """Regression guard for a previously broken ENTRYPOINT.
+
+    ENTRYPOINT previously used ``uv run``, which writes to ``~/.cache/uv`` at
+    startup. This can fail in hardened pods with read-only root filesystem and
+    non-root users.
+    """
     content = DOCKERFILE.read_text(encoding="utf-8")
     lines = [line.strip() for line in content.splitlines() if line.strip()]
 
     entrypoint = next((line for line in lines if line.startswith("ENTRYPOINT")), "")
     assert entrypoint, "Dockerfile must define an ENTRYPOINT."
     assert '"uv", "run"' not in entrypoint, (
-        "Regression guard: ENTRYPOINT previously used `uv run`, which writes to "
-        "`~/.cache/uv` and can fail in hardened pods (`readOnlyRootFilesystem: true`, non-root)."
+        "Regression guard: ENTRYPOINT must not use `uv run` because it may write "
+        "to `~/.cache/uv` at runtime."
     )
     assert '"kopf", "run"' in entrypoint, "ENTRYPOINT must execute kopf directly from the venv."
     assert '--liveness=http://0.0.0.0:8080/healthz' in entrypoint, (
-        "Regression guard: probes target /healthz on 8080, but this broke before when Kopf liveness "
-        "endpoint was not enabled in ENTRYPOINT."
+        "Regression guard: probes target /healthz on 8080, so Kopf liveness "
+        "must be enabled in ENTRYPOINT."
     )
 
 
 def test_dockerfile_exports_venv_bin_on_path() -> None:
+    """Regression guard for PATH wiring after removing ``uv run``."""
     content = DOCKERFILE.read_text(encoding="utf-8")
     assert 'ENV PATH="/app/.venv/bin:${PATH}"' in content, (
         "Regression guard: runtime must use build-time venv binaries to avoid needing `uv run`."


### PR DESCRIPTION
## Summary
- Remove `uv run` from Dockerfile ENTRYPOINT -- it writes to `~/.cache/uv` at startup, which fails with `readOnlyRootFilesystem: true` and non-root user
- Export build-time venv onto PATH (`ENV PATH="/app/.venv/bin:${PATH}"`) so `kopf` is found directly
- Add 2 runtime regression tests guarding against reintroduction

Incorporates the Dockerfile fix from #28. The SSHCluster tests from #28 are already covered by #29.

Closes #28

## Test plan
- [x] `test_docker_entrypoint_uses_kopf_directly` -- verifies no `uv run` in ENTRYPOINT
- [x] `test_dockerfile_exports_venv_bin_on_path` -- verifies PATH export
- [x] Full test suite: 38/38 passing