### PR TITLE
fix(test): resolve ruff lint and format issues in integration tests

### DIFF
--- a/python/tests/integration/helpers.py
+++ b/python/tests/integration/helpers.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import kubernetes
 
-
 API_GROUP = "infrastructure.alpininsight.ai"
 API_VERSION = "v1beta1"
 
@@ -133,4 +132,5 @@ def wait_for_status(
             return resource
         time.sleep(interval)
     status = last_resource.get("status", {}) if last_resource else {}
-    raise TimeoutError(f"{plural}/{name} in {namespace} did not meet condition within {timeout}s. Last status: {status}")
+    msg = f"{plural}/{name} in {namespace} did not meet condition within {timeout}s. Last status: {status}"
+    raise TimeoutError(msg)

--- a/python/tests/integration/test_sshcluster_integration.py
+++ b/python/tests/integration/test_sshcluster_integration.py
@@ -19,9 +19,7 @@ pytestmark = [pytest.mark.integration, pytest.mark.timeout(60)]
 class TestSSHClusterWithOwner:
     """SSHCluster with a CAPI Cluster ownerReference should become provisioned."""
 
-    def test_create_with_owner_becomes_provisioned(
-        self, custom_api, test_namespace, cluster_owner_ref
-    ):
+    def test_create_with_owner_becomes_provisioned(self, custom_api, test_namespace, cluster_owner_ref):
         """Create SSHCluster with owner → reconcile → verify provisioned status."""
         spec = {"controlPlaneEndpoint": {"host": "10.0.0.1", "port": 6443}}
         name = "test-cluster-owned"
@@ -61,9 +59,7 @@ class TestSSHClusterWithOwner:
         updated = get_sshcluster(custom_api, name, test_namespace)
         assert updated["status"]["initialization"]["provisioned"] is True
 
-    def test_idempotent_reconciliation(
-        self, custom_api, test_namespace, cluster_owner_ref
-    ):
+    def test_idempotent_reconciliation(self, custom_api, test_namespace, cluster_owner_ref):
         """Running reconcile twice on the same resource produces consistent status."""
         spec = {"controlPlaneEndpoint": {"host": "10.0.0.2", "port": 6443}}
         name = "test-cluster-idempotent"
@@ -101,9 +97,7 @@ class TestSSHClusterWithoutOwner:
 class TestSSHClusterPaused:
     """Paused SSHCluster should skip reconciliation entirely."""
 
-    def test_paused_skips_reconciliation(
-        self, custom_api, test_namespace, cluster_owner_ref
-    ):
+    def test_paused_skips_reconciliation(self, custom_api, test_namespace, cluster_owner_ref):
         """Create paused SSHCluster → reconcile → verify no status changes."""
         spec = {
             "controlPlaneEndpoint": {"host": "10.0.0.4", "port": 6443},
@@ -124,9 +118,7 @@ class TestSSHClusterPaused:
 class TestSSHClusterInvalidEndpoint:
     """SSHCluster with invalid endpoint should be marked not-ready."""
 
-    def test_empty_endpoint_not_ready(
-        self, custom_api, test_namespace, cluster_owner_ref
-    ):
+    def test_empty_endpoint_not_ready(self, custom_api, test_namespace, cluster_owner_ref):
         """Create SSHCluster with empty host → reconcile → verify InvalidEndpoint."""
         # CRD schema requires host, so we test with an empty string via direct reconcile
         spec = {"controlPlaneEndpoint": {"host": "", "port": 0}}
@@ -142,9 +134,7 @@ class TestSSHClusterInvalidEndpoint:
 class TestSSHClusterDelete:
     """SSHCluster deletion should succeed (no-op cleanup)."""
 
-    def test_delete_removes_resource(
-        self, custom_api, test_namespace, cluster_owner_ref
-    ):
+    def test_delete_removes_resource(self, custom_api, test_namespace, cluster_owner_ref):
         """Create then delete SSHCluster → verify it's gone."""
         spec = {"controlPlaneEndpoint": {"host": "10.0.0.5", "port": 6443}}
         name = "test-cluster-delete"

--- a/python/tests/integration/test_sshmachine_integration.py
+++ b/python/tests/integration/test_sshmachine_integration.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, patch
 
 import kopf
-import kubernetes
 import pytest
 
 from capi_provider_ssh.controllers.sshmachine import (


### PR DESCRIPTION
## Summary

Fix 3 ruff lint errors and 1 format issue in the integration tests merged in PR #39. These would cause CI (`ci-python.yml`) to fail.

- `I001` import sorting in `helpers.py`
- `E501` line too long in `helpers.py`
- `F401` unused `kubernetes` import in `test_sshmachine_integration.py`
- Format fix in `test_sshcluster_integration.py`

## Test plan

- [x] `ruff check src tests` passes
- [x] `ruff format --check src tests` passes
- [x] 38 unit tests pass, 14 integration tests skip (no cluster in CI)
