### PR TITLE
fix(docker): copy source before uv sync so package is installed

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -5,14 +5,12 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 WORKDIR /app
 
-# Copy dependency files first for layer caching
+# Copy all source and config for package installation
 COPY pyproject.toml uv.lock* README.md ./
-
-# Install production dependencies only
-RUN uv sync --no-dev --no-editable
-
-# Copy source code
 COPY src/ src/
+
+# Install production dependencies and the package itself
+RUN uv sync --no-dev --no-editable
 
 # Use the virtualenv created at build time; avoid runtime `uv run` cache writes.
 ENV PATH="/app/.venv/bin:${PATH}"


### PR DESCRIPTION
## Summary
- Move `COPY src/ src/` before `uv sync` so hatchling can build the package
- Without this, `capi_provider_ssh` module is not installed in the venv, causing `ModuleNotFoundError` at runtime

## Test plan
- [ ] Container starts without `ModuleNotFoundError`
- [ ] `kubectl get pods -n capi-provider-ssh-system` shows 1/1 Running after Flux reconcile