### PR TITLE
docs: formalize SSH key lifecycle (SOPS/External Secrets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ spec:
 See [docs/architecture.md](docs/architecture.md) for the full rationale and
 production-ready examples.
 
+## SSH Key Lifecycle
+
+SSH private key management is standardized for GitOps workflows:
+
+- SOPS-encrypted Secret manifests
+- External Secrets syncing from a central secret manager
+- Versioned key rotation runbook with rollback steps
+
+See [docs/ssh-key-lifecycle.md](docs/ssh-key-lifecycle.md) and
+[python/deploy/examples/ssh-key-lifecycle/](python/deploy/examples/ssh-key-lifecycle/).
+
 ## Development
 
 See [DEVELOPMENT.md](DEVELOPMENT.md) for full setup instructions.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -165,6 +165,16 @@ spec:
 | **Dry-run** | Validate prerequisites without executing bootstrap |
 | **Reboot remediation** | In-band SSH reboot for machine remediation |
 
+## SSH Key Lifecycle Boundary
+
+The provider consumes SSH private keys from Kubernetes Secrets referenced by
+`spec.sshKeyRef`; it does not generate, rotate, or escrow keys itself.
+
+- Provider contract: `spec.sshKeyRef.name` plus optional `spec.sshKeyRef.key`
+  (defaults to `value`)
+- Operational lifecycle: managed via GitOps (SOPS or External Secrets)
+- Rotation and rollback procedure: [docs/ssh-key-lifecycle.md](ssh-key-lifecycle.md)
+
 ## What the Infrastructure Provider Does NOT Do
 
 | Capability | Why Not | Where It Belongs |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,6 +12,7 @@
 | SSHHost health probing (periodic SSH connectivity checks) | Implemented |
 | Cleanup on deletion (kubeadm reset) | Implemented |
 | Pause/unpause support | Implemented |
+| SSH key lifecycle (SOPS/External Secrets + rotation runbook) | Implemented |
 
 ## Planned: Image Builder Support (v0.2.x)
 

--- a/docs/ssh-key-lifecycle.md
+++ b/docs/ssh-key-lifecycle.md
@@ -1,0 +1,72 @@
+# SSH Key Lifecycle
+
+This runbook defines a GitOps-safe lifecycle for SSH keys used by
+`SSHHost.spec.sshKeyRef` and `SSHMachine.spec.sshKeyRef`.
+
+## Secret Contract
+
+- The controller reads the private key from `spec.sshKeyRef.name`.
+- The Secret data key defaults to `value`; override with `spec.sshKeyRef.key`.
+- Use versioned Secret names (for example `ssh-key-2026q1`) to make rotation
+  explicit and auditable.
+- Do not commit plaintext private keys to Git. Use either:
+  - SOPS-encrypted Secret manifests.
+  - External Secrets syncing from an external secret manager.
+
+## GitOps Pattern A: SOPS
+
+Use an encrypted Secret manifest in Git and let Flux decrypt it at apply time.
+
+- Example: `python/deploy/examples/ssh-key-lifecycle/sops/secret.sops.yaml`
+- The manifest shape matches the provider contract (`data.value` by default).
+
+## GitOps Pattern B: External Secrets
+
+Use `ExternalSecret` to materialize the Kubernetes Secret from your central
+secret manager.
+
+- Example:
+  `python/deploy/examples/ssh-key-lifecycle/external-secrets/externalsecret.yaml`
+- The target Secret is created as `type: Opaque` with key `value`.
+
+## Rotation Runbook
+
+1. Create a new versioned key Secret (`ssh-key-YYYYqN`) via SOPS or
+   External Secrets.
+2. Canary switch one `SSHHost` and one `SSHMachine` to the new Secret.
+3. Verify readiness:
+   - `SSHHost.status.ready=True` after probe cycle.
+   - New or dry-run machine reconciliation succeeds.
+4. Roll out to all remaining `SSHHost` and `SSHMachine` objects.
+5. Keep the old Secret for a short rollback window, then remove it.
+
+### Example Patches
+
+```bash
+# Switch one SSHHost
+kubectl -n default patch sshhost host-a --type=merge \
+  -p '{"spec":{"sshKeyRef":{"name":"ssh-key-2026q1","key":"value"}}}'
+
+# Switch one SSHMachine
+kubectl -n default patch sshmachine cp-0 --type=merge \
+  -p '{"spec":{"sshKeyRef":{"name":"ssh-key-2026q1","key":"value"}}}'
+```
+
+## Audit Checks
+
+```bash
+# Inventory current SSH key refs
+kubectl get sshhosts,sshmachines -A -o custom-columns='KIND:.kind,NS:.metadata.namespace,NAME:.metadata.name,KEYSECRET:.spec.sshKeyRef.name,KEYFIELD:.spec.sshKeyRef.key'
+
+# Confirm no plaintext private key manifests under deploy/
+rg -n "BEGIN OPENSSH PRIVATE KEY|BEGIN RSA PRIVATE KEY" python/deploy
+```
+
+## Rollback
+
+If validation fails:
+
+1. Patch affected `SSHHost` and `SSHMachine` resources back to the previous
+   Secret name.
+2. Confirm probes/reconciliations are healthy again.
+3. Investigate key distribution before retrying rotation.

--- a/python/deploy/examples/ssh-key-lifecycle/README.md
+++ b/python/deploy/examples/ssh-key-lifecycle/README.md
@@ -1,0 +1,21 @@
+# SSH Key Lifecycle Examples
+
+These examples show two GitOps-safe ways to provide SSH keys for
+`SSHHost.spec.sshKeyRef` and `SSHMachine.spec.sshKeyRef`.
+
+- `sops/secret.sops.yaml`: SOPS-managed Kubernetes Secret in Git.
+- `external-secrets/externalsecret.yaml`: External Secrets sync from a central
+  secret manager into a Kubernetes Secret.
+
+Both examples create or reference a Secret with this shape:
+
+```yaml
+apiVersion: v1
+kind: Secret
+type: Opaque
+data:
+  value: <base64-encoded-private-key>
+```
+
+The provider reads `value` by default. If you use another key name, set
+`spec.sshKeyRef.key` accordingly.

--- a/python/deploy/examples/ssh-key-lifecycle/external-secrets/externalsecret.yaml
+++ b/python/deploy/examples/ssh-key-lifecycle/external-secrets/externalsecret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ssh-key-2026q1
+  namespace: default
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: platform-secrets
+  target:
+    name: ssh-key-2026q1
+    creationPolicy: Owner
+    template:
+      type: Opaque
+  data:
+    - secretKey: value
+      remoteRef:
+        key: capi-provider-ssh/default/ssh-key-2026q1
+        property: private_key

--- a/python/deploy/examples/ssh-key-lifecycle/sops/secret.sops.yaml
+++ b/python/deploy/examples/ssh-key-lifecycle/sops/secret.sops.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ssh-key-2026q1
+  namespace: default
+type: Opaque
+data:
+  value: ENC[AES256_GCM,data:REPLACE_WITH_SOPS_CIPHERTEXT,iv:REPLACE_ME,tag:REPLACE_ME,type:str]
+sops:
+  age:
+    - recipient: age1replacewithyourrecipientkey000000000000000000000000000
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        REPLACE_WITH_REAL_AGE_BLOCK
+        -----END AGE ENCRYPTED FILE-----
+  encrypted_regex: "^(data|stringData)$"
+  version: 3.9.0


### PR DESCRIPTION
## Summary
- add an SSH key lifecycle runbook for capi-provider-ssh
- add GitOps examples for SOPS and External Secrets under python/deploy/examples/ssh-key-lifecycle
- link lifecycle guidance from README and architecture docs
- mark SSH key lifecycle as implemented in roadmap

## Validation
- uv run pre-commit run --files README.md docs/architecture.md docs/roadmap.md docs/ssh-key-lifecycle.md python/deploy/examples/ssh-key-lifecycle/README.md python/deploy/examples/ssh-key-lifecycle/external-secrets/externalsecret.yaml python/deploy/examples/ssh-key-lifecycle/sops/secret.sops.yaml