### PR TITLE
fix: add explicit Flux rollout unsuspend step

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,15 @@ SSH private key management is standardized for GitOps workflows:
 See [docs/ssh-key-lifecycle.md](docs/ssh-key-lifecycle.md) and
 [python/deploy/examples/ssh-key-lifecycle/](python/deploy/examples/ssh-key-lifecycle/).
 
+## Flux Rollout
+
+If CAPI cluster reconciliation is suspended in Flux, use the explicit rollout
+procedure in [docs/flux-rollout.md](docs/flux-rollout.md) to:
+
+- reconcile provider manifests first
+- unsuspend `capi-clusters`
+- verify health and rollback quickly if needed
+
 ## Development
 
 See [DEVELOPMENT.md](DEVELOPMENT.md) for full setup instructions.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -184,6 +184,18 @@ The provider consumes SSH private keys from Kubernetes Secrets referenced by
 | Image building | Not an infra provider concern | Packer, image pipelines |
 | Generic hook framework | YAGNI -- only external etcd exists as a specific feature | Reconsider when a second use case emerges |
 
+## Flux Rollout Sequencing
+
+When management-cluster reconciliation is driven by Flux, rollout order is an
+operations concern:
+
+1. Reconcile provider manifests.
+2. Unsuspend cluster-level Kustomization (`capi-clusters`).
+3. Verify CAPI object health and provider controller health.
+
+Use [docs/flux-rollout.md](flux-rollout.md) for command-level steps and
+rollback.
+
 ## How the Bootstrap Script Flows
 
 ```

--- a/docs/flux-rollout.md
+++ b/docs/flux-rollout.md
@@ -1,0 +1,59 @@
+# Flux Rollout Step
+
+This runbook makes the CAPI rollout step explicit when Flux-managed
+`capi-clusters` are suspended.
+
+## Preconditions
+
+Run this only after the provider blockers are closed in `develop`:
+
+- RBAC includes CRD discovery (`apiextensions.k8s.io/customresourcedefinitions`)
+- Multi-host allocation is active for control plane replicas
+- SSHMachine delete/finalizer flow is validated
+
+## Rollout (Unsuspend)
+
+```bash
+# 1) Refresh Git source and provider layer first
+flux -n flux-system reconcile source git flux-system
+flux -n flux-system reconcile kustomization capi-provider-ssh --with-source
+
+# 2) Unsuspend cluster layer
+flux -n flux-system resume kustomization capi-clusters
+
+# 3) Reconcile immediately
+flux -n flux-system reconcile kustomization capi-clusters --with-source
+```
+
+If `flux` CLI is unavailable, use `kubectl`:
+
+```bash
+kubectl -n flux-system patch kustomization capi-clusters --type=merge \
+  -p '{"spec":{"suspend":false}}'
+kubectl -n flux-system annotate kustomization capi-clusters \
+  reconcile.fluxcd.io/requestedAt="$(date -u +%Y-%m-%dT%H:%M:%SZ)" --overwrite
+```
+
+## Verification
+
+```bash
+# Flux status
+flux -n flux-system get kustomizations
+
+# CAPI objects and provider inventory
+kubectl get clusters,machines -A
+kubectl get sshhosts,sshmachines -A
+
+# Provider controller health
+kubectl -n capi-provider-ssh-system get deploy,pods
+```
+
+## Rollback
+
+```bash
+# Stop rollout quickly
+flux -n flux-system suspend kustomization capi-clusters
+
+# Reconcile provider layer back to known state if needed
+flux -n flux-system reconcile kustomization capi-provider-ssh --with-source
+```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,6 +13,7 @@
 | Cleanup on deletion (kubeadm reset) | Implemented |
 | Pause/unpause support | Implemented |
 | SSH key lifecycle (SOPS/External Secrets + rotation runbook) | Implemented |
+| Flux rollout gate (explicit unsuspend/rollback runbook) | Implemented |
 
 ## Planned: Image Builder Support (v0.2.x)
 


### PR DESCRIPTION
## Summary
- add a dedicated Flux rollout runbook with explicit unsuspend, verification, and rollback steps
- link the rollout runbook from README and architecture docs
- mark Flux rollout gate as implemented in roadmap

## Validation
- uv run pre-commit run --files README.md docs/architecture.md docs/roadmap.md docs/flux-rollout.md