### PR TITLE
chore: ignore python coverage artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.pyc
 .venv/
+.coverage
 *.egg-info/
 dist/
 build/


### PR DESCRIPTION
## Summary
- add .coverage to .gitignore
- prevent local coverage output from appearing as untracked changes

## Change
- update .gitignore with .coverage under Python artifacts