### PR TITLE
docs(roadmap): protocol-based hardware plugin taxonomy

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -29,40 +29,118 @@ Move from Tier 2 (`preKubeadmCommands` for package installation) to Tier 1
 
 ## Planned: Hardware Plugin Interface (v0.3.x)
 
-Extensible plugin system for vendor-specific out-of-band (OOB) management
-operations. SSH covers in-band management, but many bare-metal operations
-require BMC/IPMI access that is vendor-specific.
+Extensible plugin system for out-of-band (OOB) management operations. SSH
+covers in-band management, but bare-metal servers and edge devices often need
+out-of-band operations — power cycling unresponsive hosts, health monitoring,
+firmware checks — that vary by **protocol**, not vendor.
 
 ### Problem
 
 The SSH provider handles in-band operations (connect, execute, reboot). But
-bare-metal servers often need out-of-band operations that vary by hardware
-vendor:
+hardware management spans a wider range of devices and use cases:
 
 - **Power management** — hard power cycle when a host is unresponsive to SSH
 - **Health monitoring** — disk, memory, PSU, temperature status before claiming
 - **Firmware queries** — BIOS/BMC version checks as pre-bootstrap gates
 - **Console access** — remote KVM for debugging boot failures
 - **LED identification** — locate a specific server in a rack
+- **Edge device power** — toggle PoE ports or GPIO relays for SBCs
 
-These operations are vendor-specific and should not be hardcoded into the
-provider core.
+These operations should not be hardcoded into the provider core.
+
+### Why Protocol-Based, Not Vendor-Based
+
+The industry confirms this direction. OpenStack Ironic started with
+vendor-specific drivers (ilo, drac, cisco-ucs) and converged on protocol-based
+generic drivers (redfish, ipmi). The Ironic community does not anticipate new
+vendor-specific hardware types since Redfish supersedes them.
+
+The key insight: multiple vendors share the same protocol. HPE iLO 5, Dell
+iDRAC 9, Lenovo XCC, and Supermicro BMCs all implement DMTF Redfish. A single
+`redfish` plugin handles all of them. Vendor-specific quirks (OEM extensions)
+are handled as configuration, not separate plugins.
+
+```
+WRONG (vendor-centric):            RIGHT (protocol-centric):
+┌─────────┐ ┌─────────┐           ┌──────────────────┐
+│  ilo5   │ │  idrac  │           │     redfish      │ ← single plugin
+└─────────┘ └─────────┘           │  HPE, Dell, SMC  │
+  Both speak Redfish!             └──────────────────┘
+```
+
+### Protocol Landscape
+
+| Protocol | Layer | Transport | Vendors / Devices | Capabilities |
+|----------|-------|-----------|-------------------|-------------|
+| **Redfish** | BMC (modern) | HTTPS + JSON | HPE iLO 5+, Dell iDRAC 8+, Lenovo XCC, Supermicro, Huawei iBMC, Cisco CIMC | Power, health, firmware, virtual media, BIOS config, RAID, telemetry |
+| **IPMI** | BMC (legacy) | UDP/RMCP+ | Nearly all x86 servers since ~2000 | Power, basic sensors, SOL console, boot device |
+| **SNMP** | Network/PDU | UDP | Smart PDUs (APC, Raritan, CyberPower), managed PoE switches | Per-outlet power on/off, environmental sensors, port control |
+| **GPIO** | Physical | Direct wiring | Raspberry Pi, Jetson, SBCs, relay boards | Relay toggle for power, pin read for status |
+
+### Device Classes
+
+Protocols alone are not enough. Devices also differ by **class** — what kind of
+hardware they are and what management operations apply:
+
+| Device Class | Examples | Management Model | Typical Protocol |
+|-------------|----------|-----------------|-----------------|
+| Enterprise server | HPE DL380, Dell R750, Lenovo SR650 | Built-in BMC (iLO, iDRAC, XCC) | Redfish, IPMI |
+| Whitebox server | Supermicro, custom builds | BMC with varying Redfish support | Redfish, IPMI |
+| GPU edge / SBC | NVIDIA Jetson Orin, Raspberry Pi 5, Rock Pi | No BMC; external power control via PDU or relay | SNMP (via PDU), GPIO |
+| Industrial edge | NVIDIA IGX Orin | OpenBMC with Redfish API | Redfish |
+| Power distribution | APC, Raritan, Server Technology | Smart PDU with per-outlet control | SNMP, HTTP API |
+
+The plugin label on SSHHost is a **protocol identifier**. Device class is
+implicit from the protocol and annotations used.
 
 ### Design
 
 ```
 SSHMachine Controller
 ├── In-band (SSH): bootstrap, cleanup, reboot — built-in
-└── Out-of-band (BMC): power, health, firmware — delegated to plugins
+└── Out-of-band: power, health, firmware — delegated to plugins
         │
         │ gRPC or exec call
         ▼
 Hardware Plugin (sidecar or standalone)
 ├── Implements HardwarePlugin contract
-└── Vendor-specific SDK (iLO, iDRAC, Redfish, IPMI)
+└── Protocol-specific client (Redfish, IPMI, SNMP, GPIO)
 ```
 
-**Plugin discovery:** SSHHost annotation or label selects the plugin:
+### Plugin Taxonomy
+
+Four plugins cover the entire hardware spectrum — from enterprise rack servers
+to Raspberry Pi edge nodes. No vendor names in plugin IDs.
+
+| Plugin ID | Protocol | Device Classes | What It Covers |
+|-----------|----------|---------------|---------------|
+| `redfish` | DMTF Redfish (HTTPS/JSON) | Enterprise servers, whitebox servers, industrial edge | HPE iLO 5+, Dell iDRAC 8+, Lenovo XCC, Supermicro, Huawei iBMC, Cisco CIMC, NVIDIA IGX Orin, any Redfish-compliant BMC |
+| `ipmi` | IPMI over LAN (RMCP+) | Legacy servers, whitebox servers | Any server with IPMI BMC (fallback for servers without Redfish) |
+| `snmp` | SNMP v2c/v3 | Smart PDUs, managed PoE switches | APC, Raritan, Server Technology, CyberPower, any managed PDU with per-outlet MIBs; PoE switches for SBC power control |
+| `gpio` | SSH + GPIO | SBCs, relay boards | Raspberry Pi, Jetson — uses a controller host to toggle GPIO pins connected to power relays |
+
+### Capability Matrix
+
+Not every plugin implements every operation. The contract uses optional
+capabilities — a `gpio` plugin reports `PowerOn`/`PowerOff`/`PowerStatus`
+but returns "unsupported" for `HealthCheck` and `FirmwareVersion`.
+
+| Operation | `redfish` | `ipmi` | `snmp` | `gpio` |
+|-----------|-----------|--------|--------|--------|
+| `PowerOn` | yes | yes | yes | yes |
+| `PowerOff` (+ force flag) | yes | yes | yes | yes |
+| `PowerCycle` | yes | yes | yes | yes |
+| `PowerStatus` | yes | yes | yes | yes |
+| `HealthCheck` | yes | yes (basic sensors) | no | no |
+| `FirmwareVersion` | yes | yes (limited) | no | no |
+| `IdentifyLED` | yes | no | no | no |
+
+### Plugin Discovery via SSHHost
+
+The `hardware-plugin` label selects the protocol. Annotations provide
+connection details specific to that protocol.
+
+**Enterprise server (Redfish BMC):**
 
 ```yaml
 apiVersion: infrastructure.alpininsight.ai/v1beta1
@@ -70,39 +148,83 @@ kind: SSHHost
 metadata:
   name: server-42
   labels:
-    hardware-plugin: ilo5
+    hardware-plugin: redfish
   annotations:
-    hardware-plugin.alpininsight.ai/endpoint: "https://ilo-server-42.mgmt.local"
+    hardware-plugin.alpininsight.ai/endpoint: "https://bmc-42.mgmt.local"
+    hardware-plugin.alpininsight.ai/secret: "bmc-credentials-42"
 spec:
   address: 10.0.0.42
   sshKeyRef:
     name: ssh-key
 ```
 
-**Plugin contract** (gRPC or exec-based sidecar):
+**Edge device managed via smart PDU (SNMP):**
 
-| Operation | Input | Output |
-|-----------|-------|--------|
-| `PowerOn` | host identifier | success/failure |
-| `PowerOff` | host identifier, force flag | success/failure |
-| `PowerCycle` | host identifier | success/failure |
-| `PowerStatus` | host identifier | on/off/unknown |
-| `HealthCheck` | host identifier | component statuses (disk, memory, PSU, fans) |
-| `FirmwareVersion` | host identifier | BIOS version, BMC version |
-| `IdentifyLED` | host identifier, on/off | success/failure |
+```yaml
+apiVersion: infrastructure.alpininsight.ai/v1beta1
+kind: SSHHost
+metadata:
+  name: rpi-node-3
+  labels:
+    hardware-plugin: snmp
+  annotations:
+    hardware-plugin.alpininsight.ai/endpoint: "192.168.1.200"
+    hardware-plugin.alpininsight.ai/outlet: "6"
+    hardware-plugin.alpininsight.ai/secret: "pdu-community"
+spec:
+  address: 10.0.0.103
+  sshKeyRef:
+    name: rpi-ssh-key
+```
 
-**Target vendor plugins:**
+**Raspberry Pi managed via GPIO relay:**
 
-| Plugin | Hardware | Protocol |
-|--------|----------|----------|
-| `ilo5` | HPE ProLiant (iLO 5/6) | Redfish REST API |
-| `idrac` | Dell PowerEdge (iDRAC 8/9) | Redfish REST API |
-| `ucs` | Cisco UCS | Cisco UCS Manager XML API |
-| `xclarity` | Lenovo ThinkSystem | Lenovo XClarity REST API |
-| `ipmi` | Generic (any IPMI-capable server) | IPMI over LAN (ipmitool) |
-| `redfish` | Generic Redfish-compliant BMC | DMTF Redfish standard |
+```yaml
+apiVersion: infrastructure.alpininsight.ai/v1beta1
+kind: SSHHost
+metadata:
+  name: rpi-worker-1
+  labels:
+    hardware-plugin: gpio
+  annotations:
+    hardware-plugin.alpininsight.ai/endpoint: "10.0.0.200"
+    hardware-plugin.alpininsight.ai/pin: "17"
+    hardware-plugin.alpininsight.ai/secret: "relay-ssh-key"
+spec:
+  address: 10.0.0.101
+  sshKeyRef:
+    name: rpi-ssh-key
+```
 
-**Integration points in the provider:**
+### Target Hardware for Startup / Edge Clusters
+
+For startups and small teams that need simple, repeatable setups on standard
+hardware without expensive vendor software, two device families stand out:
+
+| Device | GPU | Price | K8s | Power Mgmt | Software Cost |
+|--------|-----|-------|-----|------------|---------------|
+| **Raspberry Pi 5** (8GB) | None (VideoCore, no CUDA) | ~$80 | Standard kubeadm | PDU or GPIO relay | Free |
+| **Jetson Orin Nano Super** | 1024 CUDA cores, 67 TOPS | $249 (dev kit) | Standard kubeadm + nvidia-container-toolkit | PDU or GPIO relay | Free (JetPack, CUDA, TensorRT) |
+| **Jetson Orin NX 16GB** | 1024 CUDA cores, 157 TOPS | ~$599 (module + carrier) | Standard kubeadm + nvidia-container-toolkit | PDU or GPIO relay | Free |
+
+Both run standard aarch64 Linux, support kubeadm natively, and are managed
+identically by the CAPI SSH provider. Neither has a BMC — power management
+uses the `snmp` plugin (smart PDU) or `gpio` plugin (relay board).
+
+A 5-node Jetson Orin Nano Super cluster costs ~$1,700 total and provides CUDA
+GPU on every node. A mixed cluster (3x RPi workers + 2x Jetson GPU workers)
+offers the best cost/capability balance.
+
+NVIDIA Jetson software (JetPack, CUDA, cuDNN, TensorRT, container toolkit) is
+**free for commercial use** with no per-unit royalties or subscriptions. The
+GPU Operator does not support Jetson — the GPU stack is managed at the OS level
+via JetPack, which the CAPI SSH provider treats as a `preKubeadmCommands`
+concern.
+
+See [nvidia-jetson-edge-devices.md](roadmap/nvidia-jetson-edge-devices.md) for
+the full evaluation.
+
+### Integration Points
 
 1. **`_choose_host` enhancement** — optionally call `HealthCheck` before
    claiming a host, skip hosts with degraded hardware

--- a/docs/roadmap/nvidia-jetson-edge-devices.md
+++ b/docs/roadmap/nvidia-jetson-edge-devices.md
@@ -1,0 +1,203 @@
+# NVIDIA Jetson Edge Devices for CAPI SSH Provider
+
+## Status
+
+**Research complete** — informs v0.3.x hardware plugin taxonomy and device class
+coverage.
+
+## Context
+
+As a startup requiring simple, repeatable setups on standard hardware without
+expensive vendor software, NVIDIA Jetson devices are a compelling option for
+GPU-enabled edge/worker nodes in Kubernetes clusters managed by the CAPI SSH
+provider. This document evaluates the Jetson family for fit with our
+protocol-based hardware plugin architecture.
+
+## Product Lineup (Current)
+
+### Jetson Orin Family (Mainstream, Available Now)
+
+| Model | AI Perf | RAM | Power | Price |
+|-------|---------|-----|-------|-------|
+| Jetson Orin Nano Super | 67 TOPS | 8 GB | 7-25W | $249 (dev kit) |
+| Jetson Orin NX 8GB | 70 TOPS | 8 GB | 10-25W | ~$399 (module) |
+| Jetson Orin NX 16GB | 157 TOPS | 16 GB | 10-40W | ~$599 (module) |
+| Jetson AGX Orin 32GB | 200 TOPS | 32 GB | 15-40W | ~$999 (module) |
+| Jetson AGX Orin 64GB | 275 TOPS | 64 GB | 15-60W | $1,999 (dev kit) |
+
+The **Orin Nano Super** ($249 dev kit) is the best-value entry point. All Orin
+devices run JetPack 6.x (Ubuntu 22.04 aarch64), support standard kubeadm, and
+include CUDA/cuDNN/TensorRT at no additional software cost.
+
+### Jetson AGX Thor (Next Gen, Blackwell Architecture)
+
+| Model | AI Perf | RAM | Power | Price |
+|-------|---------|-----|-------|-------|
+| Jetson AGX Thor | 2,070 TOPS | 128 GB | 130W | $3,499 (dev kit) |
+
+Overkill for most clusters. Relevant only for heavy inference workloads (70B+
+parameter LLMs at the edge).
+
+### Avoid for New Deployments
+
+- Jetson Nano (original) — discontinued, Maxwell GPU, JetPack 4.x only
+- Jetson Xavier NX / AGX Xavier — approaching EOL
+
+## Management Interfaces: The Critical Finding
+
+### Standard Jetson: No BMC, No IPMI, No Redfish
+
+Jetson modules are embedded SoMs, fundamentally like Raspberry Pis regarding
+management. They have **no out-of-band management** — no BMC, no IPMI, no
+Redfish. All management is in-band via SSH or external power control.
+
+This places Jetson devices in the same CAPI plugin categories as Raspberry Pi:
+
+- **`snmp`** — power managed via a smart PDU with per-outlet SNMP control
+- **`gpio`** — power managed via a relay controller
+
+### Exception: NVIDIA IGX Orin (Enterprise)
+
+The IGX Orin is the enterprise variant with a full **OpenBMC-based BMC** and
+**Redfish API**. It provides remote power control, virtual media, telemetry,
+firmware management, and serial console. However:
+
+- Price: $2,000-5,000+ (enterprise quoting)
+- 10-year lifecycle with enterprise support
+- Designed for industrial/medical use, not startup clusters
+
+**Verdict:** IGX Orin falls under the `redfish` plugin. Standard Jetson devices
+fall under `snmp` or `gpio`, same as Raspberry Pi.
+
+### Turing Pi 2.5: Interesting Middle Ground
+
+The Turing Pi 2.5 ($359) is a mini-ITX carrier board accepting up to 4 Jetson
+Nano/NX modules with:
+
+- Built-in BMC with open-source firmware
+- Per-node remote power control (on/off/reset)
+- Serial console over LAN
+- 8-port managed Ethernet with VLAN (802.1Q)
+- Remote OS image flashing
+
+This provides BMC-like management for Jetson at reasonable cost. It only
+supports SO-DIMM form factor (Nano/NX), not AGX. If adopted, this would likely
+be a fifth plugin (`turingpi`) or extend the `gpio` plugin with a Turing Pi
+backend.
+
+## Kubernetes on Jetson
+
+### Standard kubeadm Path
+
+JetPack 6.x runs standard aarch64 Ubuntu 22.04. Kubernetes works normally:
+
+1. Flash JetPack 6.x (SD card or NVMe)
+2. Install `nvidia-container-toolkit` (included in JetPack, or via apt)
+3. Install `kubeadm`/`kubelet`/`kubectl` from standard K8s apt repo
+4. `kubeadm init` / `kubeadm join` as usual
+5. Configure containerd with NVIDIA runtime
+6. Deploy NVIDIA `k8s-device-plugin` DaemonSet
+
+GPU resources appear as `nvidia.com/gpu` in pod specs.
+
+### Caveats
+
+- **ARM64 only** — all container images must support `linux/arm64`
+- **Integrated GPU** — shares system memory, no separate VRAM pool
+- **GPU Operator not supported** — NVIDIA GPU Operator does not work on Jetson;
+  GPU stack is managed at the OS level via JetPack
+- **CAPI SSH provider** needs no GPU-specific logic — the GPU is exposed as a
+  standard Kubernetes extended resource via the device plugin
+
+### Fit with CAPI SSH Provider
+
+The CAPI SSH provider manages Jetson nodes identically to any SSH-accessible
+Linux host:
+
+| Operation | How |
+|-----------|-----|
+| Provisioning | SSH into pre-flashed node, `kubeadm join` |
+| Health probing | SSH connectivity check, kubelet status |
+| Soft reboot | SSH `sudo reboot` |
+| Hard power cycle | Via PDU (SNMP plugin) or relay (GPIO plugin) |
+| GPU workloads | No CAPI handling — k8s-device-plugin manages GPU scheduling |
+
+## Software Licensing: All Free
+
+| Component | License | Cost |
+|-----------|---------|------|
+| JetPack SDK (OS, drivers, libraries) | NVIDIA EULA | Free |
+| CUDA Toolkit | Free | Free |
+| cuDNN, TensorRT | Free | Free |
+| nvidia-container-toolkit | Apache 2.0 | Free |
+| k8s-device-plugin | Apache 2.0 | Free |
+| DeepStream SDK | Free on Jetson | Free |
+
+**No per-unit royalties, no subscriptions, no production licenses.** The EULA
+only restricts the software to NVIDIA Jetson hardware. Enterprise support
+contracts (NVIDIA AI Enterprise, ~$4,500/GPU/year) are optional and irrelevant
+for startup clusters.
+
+## Cost Comparison: 5-Node Cluster
+
+| Component | Raspberry Pi 5 (8GB) | Jetson Orin Nano Super |
+|-----------|---------------------|----------------------|
+| Compute (5 units) | $400 | $1,245 |
+| Storage (NVMe) | $200 | $250 |
+| Networking | $30 | $30 |
+| Power (adapters) | $50 | $100 |
+| Power management (smart PDU) | $40 | $40 |
+| Cases/cooling | $50 | $50 |
+| **Total** | **~$770** | **~$1,715** |
+| **GPU (CUDA)** | None | 5x CUDA GPU nodes |
+
+Jetson costs ~2x Raspberry Pi but provides CUDA GPU capability on every node.
+Both are managed identically by the CAPI SSH provider — same plugin
+architecture, same power management approach.
+
+## Power Management Recommendation
+
+For a startup cluster of 3-10 Jetson (or mixed Jetson + RPi) nodes:
+
+### Primary: Smart PDU with SNMP (recommended)
+
+- Network-managed PDU with per-outlet switching
+- APC Switched PDU, or budget: Tasmota-flashed smart plugs (~$15-20/outlet)
+- Maps to CAPI SSH provider `snmp` hardware plugin
+- Configure Jetson carrier board for auto-power-on when power restored
+
+### Alternative: Turing Pi 2.5 (for Nano/NX clusters)
+
+- 4 nodes per board with integrated BMC-like management
+- Per-node power control, serial console, VLAN networking
+- Would need a dedicated plugin backend or custom integration
+
+### Fallback: GPIO relay
+
+- Separate controller (RPi or microcontroller) toggles relay board
+- Maps to CAPI SSH provider `gpio` hardware plugin
+- Most flexible but requires custom wiring
+
+## Implications for Plugin Taxonomy
+
+No changes needed to the four-protocol taxonomy. Jetson devices fit naturally:
+
+| Device | Plugin | Notes |
+|--------|--------|-------|
+| Jetson Orin (any) + Smart PDU | `snmp` | PDU per-outlet power control |
+| Jetson Orin (any) + GPIO relay | `gpio` | Relay controller toggles power |
+| Jetson on Turing Pi 2.5 | `gpio` or future `turingpi` | BMC-like API, could be GPIO backend |
+| NVIDIA IGX Orin | `redfish` | Full OpenBMC with Redfish API |
+
+The device class table in the roadmap already covers "SBC / Edge" which
+includes Jetson. No new plugin IDs needed.
+
+## Sources
+
+- [NVIDIA Jetson Orin Product Page](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin/)
+- [NVIDIA IGX Platform](https://www.nvidia.com/en-us/edge-computing/products/igx/)
+- [IGX Orin BMC Redfish API](https://docs.nvidia.com/igx-orin/bmc/latest/redfish-api.html)
+- [Turing Pi 2.5](https://turingpi.com/product/turing-pi-2-5/)
+- [NVIDIA k8s-device-plugin](https://github.com/NVIDIA/k8s-device-plugin)
+- [Cloud-Native on Jetson](https://developer.nvidia.com/embedded/jetson-cloud-native)
+- [JetPack EULA](https://docs.nvidia.com/jetson/jetpack/eula/index.html)

--- a/docs/roadmap/protocol-based-hardware-taxonomy.md
+++ b/docs/roadmap/protocol-based-hardware-taxonomy.md
@@ -1,0 +1,149 @@
+# Protocol-Based Hardware Plugin Taxonomy
+
+## Status
+
+**Accepted** — incorporated into `docs/roadmap.md` v0.3.x section.
+
+## Context
+
+The original `docs/roadmap.md` listed hardware plugins by vendor name (`ilo5`,
+`idrac`, `ucs`, `xclarity`). This created unnecessary duplication — HPE iLO and
+Dell iDRAC both speak Redfish, yet they would be separate plugins. Worse, it
+baked vendor lock-in into the design itself.
+
+The industry confirms this direction: OpenStack Ironic started with
+vendor-specific drivers and converged on protocol-based generic drivers
+(redfish, ipmi). The Ironic community does not anticipate new vendor-specific
+types since Redfish supersedes them.
+
+## Decision
+
+Redesign the hardware plugin taxonomy around **protocols and device classes**
+instead of vendor names. Expand coverage to include edge devices (Raspberry Pi,
+SBCs) and power distribution (smart PDUs).
+
+## Protocol Landscape
+
+| Protocol | Layer | Transport | Vendors / Devices | Capabilities |
+|----------|-------|-----------|-------------------|-------------|
+| **Redfish** | BMC (modern) | HTTPS + JSON | HPE iLO 5+, Dell iDRAC 8+, Lenovo XCC, Supermicro, Huawei iBMC, Cisco CIMC | Power, health, firmware, virtual media, BIOS config, RAID, telemetry |
+| **IPMI** | BMC (legacy) | UDP/RMCP+ | Nearly all x86 servers since ~2000 | Power, basic sensors, SOL console, boot device |
+| **SNMP** | Network/PDU | UDP | Smart PDUs (APC, Raritan, CyberPower), managed PoE switches | Per-outlet power on/off, environmental sensors, port control |
+| **GPIO** | Physical | Direct wiring | Raspberry Pi, Jetson, SBCs, relay boards | Relay toggle for power, pin read for status |
+
+## Key Insight: Protocol != Vendor
+
+```
+WRONG (vendor-centric):            RIGHT (protocol-centric):
+┌─────────┐ ┌─────────┐           ┌──────────────────┐
+│  ilo5   │ │  idrac  │           │     redfish      │ ← single plugin
+└─────────┘ └─────────┘           │  HPE, Dell, SMC  │
+  Both speak Redfish!             └──────────────────┘
+```
+
+Multiple vendors share the same protocol. A single `redfish` plugin handles
+HPE iLO 5, Dell iDRAC 9, Lenovo XCC, and Supermicro BMC because they all
+implement the DMTF Redfish standard. Vendor-specific quirks (extended OEM
+schemas) are handled as configuration, not separate plugins.
+
+## Device Classes (second axis)
+
+| Device Class | Examples | Management Model | Typical Protocol |
+|-------------|----------|-----------------|-----------------|
+| Enterprise server | HPE DL380, Dell R750, Lenovo SR650 | Built-in BMC (iLO, iDRAC, XCC) | Redfish, IPMI |
+| Whitebox server | Supermicro, custom builds | BMC with varying Redfish support | Redfish, IPMI |
+| GPU edge / SBC | NVIDIA Jetson Orin, Raspberry Pi 5, Rock Pi | No BMC; external power control via PDU or relay | SNMP (via PDU), GPIO |
+| Industrial edge | NVIDIA IGX Orin | OpenBMC with Redfish API | Redfish |
+| Power distribution | APC, Raritan, Server Technology | Smart PDU with per-outlet control | SNMP, HTTP API |
+
+## Final Plugin Taxonomy
+
+Four plugins cover the entire hardware spectrum:
+
+| Plugin ID | Protocol | Device Classes | What It Covers |
+|-----------|----------|---------------|---------------|
+| `redfish` | DMTF Redfish (HTTPS/JSON) | Enterprise servers, whitebox servers, industrial edge | HPE iLO 5+, Dell iDRAC 8+, Lenovo XCC, Supermicro, Huawei iBMC, Cisco CIMC, NVIDIA IGX Orin, any Redfish-compliant BMC |
+| `ipmi` | IPMI over LAN (RMCP+) | Legacy servers, whitebox servers | Any server with IPMI BMC (fallback for servers without Redfish) |
+| `snmp` | SNMP v2c/v3 | Smart PDUs, managed PoE switches | APC, Raritan, Server Technology, CyberPower, any managed PDU with per-outlet MIBs; PoE switches for SBC power control |
+| `gpio` | SSH + GPIO | SBCs, relay boards | Raspberry Pi, Jetson — uses a controller host to toggle GPIO pins connected to power relays |
+
+## Capability Matrix
+
+| Operation | `redfish` | `ipmi` | `snmp` | `gpio` |
+|-----------|-----------|--------|--------|--------|
+| `PowerOn` | yes | yes | yes | yes |
+| `PowerOff` (+ force flag) | yes | yes | yes | yes |
+| `PowerCycle` | yes | yes | yes | yes |
+| `PowerStatus` | yes | yes | yes | yes |
+| `HealthCheck` | yes | yes (basic sensors) | no | no |
+| `FirmwareVersion` | yes | yes (limited) | no | no |
+| `IdentifyLED` | yes | no | no | no |
+
+## SSHHost Examples
+
+### Enterprise server (Redfish BMC)
+
+```yaml
+apiVersion: infrastructure.alpininsight.ai/v1beta1
+kind: SSHHost
+metadata:
+  name: server-42
+  labels:
+    hardware-plugin: redfish
+  annotations:
+    hardware-plugin.alpininsight.ai/endpoint: "https://bmc-42.mgmt.local"
+    hardware-plugin.alpininsight.ai/secret: "bmc-credentials-42"
+spec:
+  address: 10.0.0.42
+  sshKeyRef:
+    name: ssh-key
+```
+
+### Edge device managed via smart PDU (SNMP)
+
+```yaml
+apiVersion: infrastructure.alpininsight.ai/v1beta1
+kind: SSHHost
+metadata:
+  name: rpi-node-3
+  labels:
+    hardware-plugin: snmp
+  annotations:
+    hardware-plugin.alpininsight.ai/endpoint: "192.168.1.200"
+    hardware-plugin.alpininsight.ai/outlet: "6"
+    hardware-plugin.alpininsight.ai/secret: "pdu-community"
+spec:
+  address: 10.0.0.103
+  sshKeyRef:
+    name: rpi-ssh-key
+```
+
+### Raspberry Pi managed via GPIO relay
+
+```yaml
+apiVersion: infrastructure.alpininsight.ai/v1beta1
+kind: SSHHost
+metadata:
+  name: rpi-worker-1
+  labels:
+    hardware-plugin: gpio
+  annotations:
+    hardware-plugin.alpininsight.ai/endpoint: "10.0.0.200"
+    hardware-plugin.alpininsight.ai/pin: "17"
+    hardware-plugin.alpininsight.ai/secret: "relay-ssh-key"
+spec:
+  address: 10.0.0.101
+  sshKeyRef:
+    name: rpi-ssh-key
+```
+
+## Changes Made
+
+- Replaced vendor-centric plugin table (`ilo5`, `idrac`, `ucs`, `xclarity`)
+  with protocol-based taxonomy (`redfish`, `ipmi`, `snmp`, `gpio`)
+- Added device class discussion explaining why protocol + device class replaces
+  vendor name
+- Added SBC/edge and PDU coverage (Raspberry Pi, smart PDUs)
+- Added capability matrix showing which operations each plugin supports
+- Added SSHHost label examples for each plugin type
+- Added rationale section referencing Ironic's evolution as precedent


### PR DESCRIPTION
## Summary
- Replace vendor-centric plugin taxonomy (ilo5, idrac, ucs, xclarity) with protocol-based design (redfish, ipmi, snmp, gpio) in the v0.3.x roadmap section
- Add NVIDIA Jetson edge device evaluation covering product lineup, management interfaces, K8s compatibility, licensing, and cost analysis
- Add protocol-based taxonomy decision document with OpenStack Ironic precedent as rationale

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Review protocol landscape table for accuracy
- [ ] Review Jetson product lineup pricing and specs