### PR TITLE
fix(ci): prevent release image loss from concurrency cancellation

### DIFF
--- a/.github/workflows/container-build-python.yml
+++ b/.github/workflows/container-build-python.yml
@@ -4,12 +4,12 @@ on:
   push:
     branches: [develop, main]
   pull_request:
-    branches: [develop]
+    branches: [develop, main]
   workflow_dispatch:
 
 concurrency:
   group: container-python-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read
@@ -30,14 +30,14 @@ jobs:
           fetch-depth: 0
 
       - name: Set up GitVersion
-        uses: gittools/actions/gitversion/setup@v3.1.2
+        uses: gittools/actions/gitversion/setup@8fedf8a6f6cec22c9eaa66ee693f5b1f315dcbdd # v3.1.2
         with:
           versionSpec: '5.x'
           preferLatestVersion: true
 
       - name: Calculate version
         id: gitversion
-        uses: gittools/actions/gitversion/execute@v3.1.2
+        uses: gittools/actions/gitversion/execute@8fedf8a6f6cec22c9eaa66ee693f5b1f315dcbdd # v3.1.2
         with:
           useConfigFile: true
           configFilePath: GitVersion.yml


### PR DESCRIPTION
## Summary

Addresses review feedback on PR #77 (Release v0.3.0):

- **Concurrency fix** (Codex P1): `cancel-in-progress` is now conditional — disabled on `main` so semver container tags always publish to completion, enabled on `develop`/PR branches where skipping intermediate builds is safe
- **SHA pinning**: `gittools/actions` pinned to commit SHA (`8fedf8a6`) for supply-chain consistency with the other actions in this workflow
- **PR CI coverage**: Added `main` to `pull_request.branches` so the container build workflow runs as a check on release PRs

## Test plan

- [ ] CI passes on this PR (validates the new `main` PR trigger)
- [ ] After merge to `develop`: pre-release container tag published
- [ ] Verify `cancel-in-progress` expression renders correctly in Actions UI