### PR TITLE
fix(ci): inherit version bumps from develop on main merge

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -15,7 +15,7 @@ branches:
     mode: ContinuousDelivery
     tag: ''
     increment: Patch
-    prevent-increment-of-merged-branch-version: true
+    prevent-increment-of-merged-branch-version: false
     track-merge-target: false
     is-release-branch: true
     is-mainline: true


### PR DESCRIPTION
## Summary

Fixes GitVersion configuration so that `feat:` commits merged from `develop` to `main` correctly produce a **minor** version bump instead of always defaulting to **patch**.

**Root cause**: `prevent-increment-of-merged-branch-version: true` on the `main` branch config told GitVersion to ignore the version calculated on `develop`. Since the merge commit itself is not a `feat:` message, only `increment: Patch` applied — producing v0.2.3 instead of the expected v0.3.0.

**Fix**: Set `prevent-increment-of-merged-branch-version: false` so `main` inherits the minor/major increment from the merged branch.

## Test plan

- [ ] CI passes
- [ ] After merge: next `develop` → `main` release PR produces the correct semver (v0.3.0)
- [ ] `develop` branch versioning unchanged (still `alpha` pre-release tags)