### PR TITLE
fix(ci): sync changelog workflow from canonical template

### DIFF
--- a/.github/docs/centralized-workflows.md
+++ b/.github/docs/centralized-workflows.md
@@ -1,0 +1,210 @@
+# Centralized Workflows
+
+This document describes the standardized GitHub Actions workflows that all
+Alpine Insight repositories should adopt. These workflows are designed to work
+consistently across repos with and without branch protection rules.
+
+## Table of Contents
+
+- [Changelog Workflow](#changelog-workflow)
+- [GitVersion Configuration](#gitversion-configuration)
+- [Required Secrets](#required-secrets)
+- [Repository Settings](#repository-settings)
+
+---
+
+## Changelog Workflow
+
+**File:** `.github/workflows/changelog.yml`
+
+Automatically generates `CHANGELOG.md` using [git-cliff](https://git-cliff.org/)
+when commits are pushed to the `develop` branch.
+
+### How It Works
+
+1. **Trigger:** Push to `develop` (excluding changes to `CHANGELOG.md` itself)
+2. **Generate:** Runs `git-cliff` to produce an updated `CHANGELOG.md`
+3. **PR Creation:** Creates (or updates) a PR from `chore/changelog-update` to `develop`
+4. **Auto-merge:** Uses `gh pr merge --auto` to let GitHub merge the PR once
+   all required checks pass. Falls back to direct merge for repos without
+   required checks or without auto-merge enabled.
+
+### Key Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| PR-based merge (not direct push) | Works with branch protection rules that require PRs |
+| `CHANGELOG_BOT_TOKEN` PAT | `GITHUB_TOKEN` cannot merge PRs when branch protection requires reviews or status checks from a different actor |
+| `gh pr merge --auto` | Lets GitHub handle check-waiting natively; no fragile polling loops or timeouts |
+| `paths-ignore: ['CHANGELOG.md']` | Prevents infinite trigger loops when the changelog PR merges |
+| No `[skip ci]` in commit message | Required checks must run on the changelog PR for it to be mergeable |
+| `concurrency` group | Prevents race conditions when multiple pushes happen in quick succession |
+| Fallback to direct merge | Repos without required checks or auto-merge enabled still work |
+
+### Adapting for Your Repo
+
+The workflow is identical across all repos. No repo-specific customization is
+needed. The auto-merge fallback handles the difference between repos with and
+without required checks.
+
+### Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `Missing CHANGELOG_BOT_TOKEN secret` error | Secret not configured | Add `CHANGELOG_BOT_TOKEN` in repo Settings > Secrets |
+| PR created but not merged | Auto-merge not enabled + required checks exist | Enable "Allow auto-merge" in repo Settings > General |
+| `Auto-merge unavailable, attempting direct merge` then fails | Required checks block direct merge | Enable auto-merge in repo settings |
+| Changelog not updating | `cliff.toml` missing or misconfigured | Ensure `cliff.toml` exists in repo root |
+
+---
+
+## GitVersion Configuration
+
+**File:** `GitVersion.yml`
+
+All repos use [GitVersion 5.x](https://gitversion.net/) for semantic versioning
+based on conventional commits.
+
+### Standard Configuration
+
+```yaml
+# GitVersion 5.x Configuration
+mode: ContinuousDelivery
+tag-prefix: '[vV]?'
+next-version: 0.1.0
+assembly-versioning-scheme: MajorMinorPatch
+commit-message-incrementing: Enabled
+major-version-bump-message: '(\+semver:\s?(breaking|major))|^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.+\))?!:|BREAKING CHANGE:'
+minor-version-bump-message: '(\+semver:\s?(feature|minor))|^feat(\(.+\))?:'
+patch-version-bump-message: '(\+semver:\s?(fix|patch))|^(fix|perf)(\(.+\))?:'
+no-bump-message: '(\+semver:\s?(skip|none))|^(chore|docs|style|test|ci|build|revert)(\(.+\))?:'
+branches:
+  main:
+    regex: ^main$
+    mode: ContinuousDelivery
+    tag: ''
+    increment: Patch
+    prevent-increment-of-merged-branch-version: false  # CRITICAL
+    track-merge-target: false
+    is-release-branch: true
+    is-mainline: true
+  develop:
+    regex: ^develop$
+    mode: ContinuousDelivery
+    tag: alpha
+    increment: Minor
+    prevent-increment-of-merged-branch-version: false
+    track-merge-target: true
+    is-release-branch: false
+    is-mainline: false
+  feature:
+    regex: ^(feature|feat)[/-]
+    mode: ContinuousDelivery
+    tag: alpha.{BranchName}
+    increment: Inherit
+    source-branches: ['develop', 'main']
+  hotfix:
+    regex: ^hotfix[/-]
+    mode: ContinuousDelivery
+    tag: beta
+    increment: Patch
+    source-branches: ['main']
+  release:
+    regex: ^release[/-]
+    mode: ContinuousDelivery
+    tag: rc
+    increment: None
+    source-branches: ['develop']
+  ci:
+    regex: ^ci[/-]
+    mode: ContinuousDelivery
+    tag: ci.{BranchName}
+    increment: Inherit
+    source-branches: ['develop']
+  docs:
+    regex: ^docs[/-]
+    mode: ContinuousDelivery
+    tag: docs.{BranchName}
+    increment: Inherit
+    source-branches: ['develop']
+  fix:
+    regex: ^fix[/-]
+    mode: ContinuousDelivery
+    tag: fix.{BranchName}
+    increment: Inherit
+    source-branches: ['develop']
+```
+
+### Critical Setting: `prevent-increment-of-merged-branch-version`
+
+This setting **must be `false`** on the `main` branch. When set to `true`
+(the GitVersion default for mainline branches), it causes `feat:` commits
+merged from `develop` to `main` to produce **patch** bumps instead of the
+correct **minor** bumps.
+
+**Why this happens:** With `true`, GitVersion ignores the commit message-based
+increment calculated on the source branch and falls back to the `increment`
+setting on `main` (which is `Patch`). Setting it to `false` lets the
+conventional commit prefix (`feat:` = minor, `fix:` = patch) flow through
+correctly.
+
+### Version Bump Rules
+
+| Commit Prefix | Version Bump | Example |
+|---------------|-------------|---------|
+| `feat:` | Minor (0.X.0) | `feat(api): add user endpoint` |
+| `fix:`, `perf:` | Patch (0.0.X) | `fix(auth): handle expired tokens` |
+| `feat!:`, `BREAKING CHANGE:` | Major (X.0.0) | `feat!: redesign auth flow` |
+| `chore:`, `docs:`, `ci:`, `test:`, `build:`, `style:`, `revert:` | None | `chore: update deps` |
+| `+semver: minor` | Minor (override) | Any commit with `+semver: minor` in body |
+
+---
+
+## Required Secrets
+
+| Secret | Purpose | Required By |
+|--------|---------|-------------|
+| `CHANGELOG_BOT_TOKEN` | Fine-grained PAT for changelog PR creation and merge | changelog.yml |
+
+### Creating the PAT
+
+1. Go to GitHub Settings > Developer settings > Personal access tokens > Fine-grained tokens
+2. Create a token scoped to the `alpininsight` organization
+3. **Permissions:** Contents (read/write), Pull requests (read/write), Metadata (read)
+4. **Resource access:** Apply to all repos that use the changelog workflow
+5. Add as a repository secret named `CHANGELOG_BOT_TOKEN`
+
+### Rotation
+
+- Set a reasonable expiry (e.g., 1 year)
+- Document the expiry date and set a calendar reminder
+- When rotating, update the secret in all repos simultaneously
+
+---
+
+## Repository Settings
+
+For the changelog workflow to work optimally with branch protection:
+
+1. **Enable "Allow auto-merge"** in repo Settings > General > Pull Requests
+   - This allows `gh pr merge --auto` to queue the PR for merge after checks pass
+   - Without this, repos with required checks will need the auto-merge fallback
+
+2. **Branch protection on `develop`** (if applicable):
+   - The `CHANGELOG_BOT_TOKEN` PAT must belong to a user/app that satisfies
+     the branch protection requirements
+   - If reviews are required, consider exempting the bot user or using a
+     GitHub App with bypass permissions
+
+---
+
+## Adoption Checklist
+
+When adding these workflows to a new repo:
+
+- [ ] Copy `changelog.yml` to `.github/workflows/`
+- [ ] Copy `GitVersion.yml` to repo root
+- [ ] Ensure `cliff.toml` exists (git-cliff configuration)
+- [ ] Add `CHANGELOG_BOT_TOKEN` secret to the repo
+- [ ] Enable "Allow auto-merge" in repo settings (recommended)
+- [ ] Verify `prevent-increment-of-merged-branch-version: false` on `main` branch

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,7 +1,6 @@
 ---
 # =============================================================================
 # Changelog Workflow - Auto-generate CHANGELOG.md on develop
-# Triggers on push to develop branch
 # =============================================================================
 
 name: Changelog
@@ -12,24 +11,27 @@ on:
       - develop
     paths-ignore:
       - 'CHANGELOG.md'
-
   workflow_dispatch:
 
 permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: changelog-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   changelog:
-    name: Generate Changelog
+    name: Generate CHANGELOG.md
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.CHANGELOG_BOT_TOKEN != '' && secrets.CHANGELOG_BOT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Install git-cliff
         uses: taiki-e/install-action@v2
@@ -37,60 +39,89 @@ jobs:
           tool: git-cliff@2.7.0
 
       - name: Generate changelog
-        id: changelog
+        id: generate
         run: |
           git-cliff --output CHANGELOG.md
 
           if [ -n "$(git status --porcelain CHANGELOG.md)" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "Changelog updated"
+            echo "CHANGELOG.md updated."
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "No changelog changes detected"
+            echo "No changelog updates."
           fi
 
-      - name: Create and merge Pull Request
-        if: steps.changelog.outputs.changed == 'true'
+      - name: Ensure changelog bot token is configured
+        if: steps.generate.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BOT_TOKEN: ${{ secrets.CHANGELOG_BOT_TOKEN }}
         run: |
+          if [ -z "${BOT_TOKEN:-}" ]; then
+            echo "::error::Missing CHANGELOG_BOT_TOKEN secret. Configure it in repo Settings > Secrets."
+            exit 1
+          fi
+
+      - name: Create or update changelog PR
+        id: pr
+        if: steps.generate.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CHANGELOG_BOT_TOKEN }}
+        run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           BRANCH="chore/changelog-update"
-          git checkout -b "$BRANCH"
+          git checkout -B "$BRANCH"
           git add CHANGELOG.md
-          git commit -m "chore(changelog): update CHANGELOG.md [skip ci]"
+          git commit -m "chore(changelog): update CHANGELOG.md"
           git push --force origin "$BRANCH"
 
-          PR_CREATE_STATUS=0
-          PR_CREATE_OUTPUT="$(
+          PR_NUM="$(gh pr list --head "$BRANCH" --base develop --json number --jq '.[0].number')"
+          if [ -n "$PR_NUM" ] && [ "$PR_NUM" != "null" ]; then
+            echo "Updating existing PR #$PR_NUM"
+            gh pr edit "$PR_NUM" \
+              --title "chore(changelog): update CHANGELOG.md" \
+              --body "Auto-generated changelog update from git-cliff."
+          else
+            echo "Creating new PR from $BRANCH to develop"
             gh pr create \
               --base develop \
               --head "$BRANCH" \
               --title "chore(changelog): update CHANGELOG.md" \
-              --body "Auto-generated changelog update from git-cliff." \
-              --label documentation \
-              2>&1
-          )" || PR_CREATE_STATUS=$?
-
-          if [ "$PR_CREATE_STATUS" -ne 0 ]; then
-            if printf '%s' "$PR_CREATE_OUTPUT" | grep -qi "already exists"; then
-              echo "Changelog PR already exists for branch $BRANCH, continuing."
-            else
-              echo "::error::Failed to create changelog PR."
-              echo "$PR_CREATE_OUTPUT"
-              exit 1
-            fi
-          else
-            echo "$PR_CREATE_OUTPUT"
+              --body "Auto-generated changelog update from git-cliff."
           fi
 
-          PR_NUM="$(gh pr list --head "$BRANCH" --json number --jq '.[0].number')"
+          PR_NUM="$(gh pr list --state open --head "$BRANCH" --base develop --json number --jq '.[0].number')"
+          if [ -z "$PR_NUM" ] || [ "$PR_NUM" = "null" ]; then
+            echo "::error::Could not resolve changelog PR number."
+            exit 1
+          fi
+          echo "pr_number=$PR_NUM" >> "$GITHUB_OUTPUT"
 
-          if [ -n "$PR_NUM" ] && [ "$PR_NUM" != "null" ]; then
-            echo "Merging PR #$PR_NUM"
+      - name: Merge changelog PR
+        if: steps.generate.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CHANGELOG_BOT_TOKEN }}
+        run: |
+          set -euo pipefail
+          PR_NUM="${{ steps.pr.outputs.pr_number }}"
+          STATE="$(gh pr view "$PR_NUM" --json state --jq '.state')"
+          if [ "$STATE" != "OPEN" ]; then
+            echo "PR #$PR_NUM is $STATE; skipping merge."
+            exit 0
+          fi
+          # Use auto-merge: GitHub waits for required checks then merges.
+          # Falls back to direct merge for repos without required checks
+          # or where auto-merge is not enabled in repo settings.
+          if gh pr merge "$PR_NUM" --auto --squash --delete-branch 2>/dev/null; then
+            echo "Auto-merge enabled on PR #$PR_NUM. GitHub will merge when checks pass."
+          else
+            echo "Auto-merge unavailable, attempting direct merge..."
             gh pr merge "$PR_NUM" --squash --delete-branch
-          else
-            echo "::warning::Could not find PR to merge"
           fi
+
+      - name: Summary
+        run: |
+          echo "### Changelog workflow result" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Changed: ${{ steps.generate.outputs.changed }}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- Replace changelog workflow with canonical PR+auto-merge pattern
- Add centralized workflow documentation

Part of org-wide CI workflow synchronization (insight-lima-k8s-capi PR #256 as reference).

## Test plan

- [ ] Changelog workflow triggers on next push to develop
- [ ] Auto-merge creates and merges changelog PR