### PR TITLE
docs: fix minor documentation inaccuracies

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Two implementations sharing the same CRDs and contract:
 
 | Implementation | Directory | Language | Framework |
 |---------------|-----------|----------|-----------|
-| Python | `python/` | Python 3.13 | kopf + asyncssh |
+| Python | `python/` | Python 3.13+ | kopf + asyncssh |
 | Rust | `rust/` | Rust (stable) | kube-rs + russh |
 
 ## Purpose
@@ -129,6 +129,11 @@ use [docs/live-rollout-validation.md](docs/live-rollout-validation.md).
 
 For promoting staging to production traffic with rollback safety, use
 [docs/dns-cutover.md](docs/dns-cutover.md).
+
+## FAQ
+
+See [docs/faq.md](docs/faq.md) for answers to common questions about RBAC/Kopf
+permissions, cleanup behavior, health probing details, and troubleshooting.
 
 ## Development
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-## Current Capabilities (v0.1.x)
+## Current Capabilities (v0.3.x)
 
 | Feature | Status |
 |---------|--------|


### PR DESCRIPTION
## Summary

- Update Python version string from `3.13` to `3.13+` to match `pyproject.toml`'s `requires-python = ">=3.13"`
- Add FAQ section (after DNS Cutover, before Development) linking to `docs/faq.md`
- Update roadmap version header from `v0.1.x` to `v0.3.x` since latest release is v0.3.0

## Test plan

- [x] All doc links resolve (`docs/faq.md` exists)
- [x] Changes limited to documentation only — no code impact