### PR TITLE
fix(capi): add status.ready, RBAC aggregation, and CRD contract labels

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
       - id: end-of-file-fixer
       - id: check-merge-conflict
       - id: check-yaml
+        args: ["--allow-multiple-documents"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deploy:** Harden deployment for Gatekeeper compliance and kind e2e
 - **docker:** Copy source before uv sync so package is installed
 - **python:** Switch to flat layout for Python 3.14 compatibility
-- **docker:** Copy source before uv sync so package is installed 
+- **docker:** Copy source before uv sync so package is installed
 - **ci:** Update CI paths for flat layout and resolve merge conflict
 - **python:** Allow controller CRD discovery in RBAC
 - **python:** Harden SSHHost claim and release semantics
 - **python:** Requeue reboot remediation until machine is ready
 - **python:** Prioritize unknown hosts and clear dry-run failures
-- **flux:** Add explicit Flux rollout unsuspend step 
+- **flux:** Add explicit Flux rollout unsuspend step
 - **docs:** Add provider-first ordering to kubectl fallback in flux runbook
 - **ci:** Self-sufficient container tagging with GitVersion and OCI labels
 - **ci:** Guard semver tag on main against no-bump commits
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **faq:** Add staging-to-production DNS swap guidance
 - Add RBAC requirements and external etcd contract documentation
 - **external-etcd:** Fix missing ClusterConfiguration behavior description
-- Fix minor documentation inaccuracies 
+- Fix minor documentation inaccuracies
 
 ### Features
 
@@ -77,7 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **python:** Add unit tests for all controllers and SSH client
 - **python:** Add runtime startup regression guard
-- **python:** Add integration tests for SSHCluster and SSHMachine 
+- **python:** Add integration tests for SSHCluster and SSHMachine
 
 ## [0.1.0] - 2026-02-20
 

--- a/python/capi_provider_ssh/controllers/sshcluster.py
+++ b/python/capi_provider_ssh/controllers/sshcluster.py
@@ -61,6 +61,7 @@ def _reconcile(spec: dict, name: str, namespace: str, meta: dict, patch: kopf.Pa
     if not _has_capi_cluster_owner(owner_refs):
         logger.warning("SSHCluster %s/%s has no CAPI Cluster owner, waiting", namespace, name)
         patch.status["initialization"] = {"provisioned": False}
+        patch.status["ready"] = False
         patch.status["conditions"] = [
             _not_ready_condition("WaitingForClusterOwner", "No CAPI Cluster ownerReference found"),
         ]
@@ -72,12 +73,14 @@ def _reconcile(spec: dict, name: str, namespace: str, meta: dict, patch: kopf.Pa
 
     if not host or not port:
         patch.status["initialization"] = {"provisioned": False}
+        patch.status["ready"] = False
         patch.status["conditions"] = [
             _not_ready_condition("InvalidEndpoint", f"Invalid controlPlaneEndpoint: {host}:{port}"),
         ]
         return
 
     patch.status["initialization"] = {"provisioned": True}
+    patch.status["ready"] = True
     patch.status["conditions"] = [
         _ready_condition(f"Control plane endpoint {host}:{port} registered"),
     ]

--- a/python/deploy/rbac.yaml
+++ b/python/deploy/rbac.yaml
@@ -56,3 +56,31 @@ subjects:
   - kind: ServiceAccount
     name: capi-provider-ssh-controller
     namespace: capi-provider-ssh-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: capi-provider-ssh-aggregated
+  labels:
+    cluster.x-k8s.io/aggregate-to-manager: "true"
+rules:
+  - apiGroups: ["infrastructure.alpininsight.ai"]
+    resources: ["sshclusters", "sshhosts", "sshmachines", "sshmachinetemplates"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["infrastructure.alpininsight.ai"]
+    resources: ["sshclusters/status", "sshhosts/status", "sshmachines/status"]
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: capi-provider-ssh-kcp-aggregated
+  labels:
+    kubeadm.controlplane.cluster.x-k8s.io/aggregate-to-manager: "true"
+rules:
+  - apiGroups: ["infrastructure.alpininsight.ai"]
+    resources: ["sshclusters", "sshhosts", "sshmachines", "sshmachinetemplates"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["infrastructure.alpininsight.ai"]
+    resources: ["sshclusters/status", "sshhosts/status", "sshmachines/status"]
+    verbs: ["get", "update", "patch"]

--- a/python/tests/test_sshcluster.py
+++ b/python/tests/test_sshcluster.py
@@ -39,12 +39,14 @@ class TestSSHClusterReconcile:
         patch = kopf.Patch({})
         _reconcile(sshcluster_spec, "test", "default", sshcluster_meta_no_owner, patch)
         assert patch["status"]["initialization"]["provisioned"] is False
+        assert patch["status"]["ready"] is False
         assert patch["status"]["conditions"][0]["reason"] == "WaitingForClusterOwner"
 
     def test_valid_cluster_provisioned(self, sshcluster_spec, sshcluster_meta_with_owner):
         patch = kopf.Patch({})
         _reconcile(sshcluster_spec, "test", "default", sshcluster_meta_with_owner, patch)
         assert patch["status"]["initialization"]["provisioned"] is True
+        assert patch["status"]["ready"] is True
         assert patch["status"]["conditions"][0]["status"] == "True"
         assert patch["status"]["conditions"][0]["reason"] == "Provisioned"
 
@@ -53,6 +55,7 @@ class TestSSHClusterReconcile:
         patch = kopf.Patch({})
         _reconcile(spec, "test", "default", sshcluster_meta_with_owner, patch)
         assert patch["status"]["initialization"]["provisioned"] is False
+        assert patch["status"]["ready"] is False
         assert patch["status"]["conditions"][0]["reason"] == "InvalidEndpoint"
 
     def test_idempotent_reconciliation(self, sshcluster_spec, sshcluster_meta_with_owner):

--- a/shared/crds/sshcluster.yaml
+++ b/shared/crds/sshcluster.yaml
@@ -4,6 +4,7 @@ metadata:
   name: sshclusters.infrastructure.alpininsight.ai
   labels:
     cluster.x-k8s.io/provider: infrastructure-ssh
+    cluster.x-k8s.io/v1beta1: v1beta1
 spec:
   group: infrastructure.alpininsight.ai
   versions:
@@ -63,6 +64,9 @@ spec:
                         type: string
                       message:
                         type: string
+                ready:
+                  type: boolean
+                  description: Legacy readiness flag for KCP compatibility (mirrors initialization.provisioned).
                 failureReason:
                   type: string
                 failureMessage:

--- a/shared/crds/sshhost.yaml
+++ b/shared/crds/sshhost.yaml
@@ -4,6 +4,7 @@ metadata:
   name: sshhosts.infrastructure.alpininsight.ai
   labels:
     cluster.x-k8s.io/provider: infrastructure-ssh
+    cluster.x-k8s.io/v1beta1: v1beta1
 spec:
   group: infrastructure.alpininsight.ai
   versions:

--- a/shared/crds/sshmachine.yaml
+++ b/shared/crds/sshmachine.yaml
@@ -4,6 +4,7 @@ metadata:
   name: sshmachines.infrastructure.alpininsight.ai
   labels:
     cluster.x-k8s.io/provider: infrastructure-ssh
+    cluster.x-k8s.io/v1beta1: v1beta1
 spec:
   group: infrastructure.alpininsight.ai
   versions:

--- a/shared/crds/sshmachinetemplate.yaml
+++ b/shared/crds/sshmachinetemplate.yaml
@@ -4,6 +4,7 @@ metadata:
   name: sshmachinetemplates.infrastructure.alpininsight.ai
   labels:
     cluster.x-k8s.io/provider: infrastructure-ssh
+    cluster.x-k8s.io/v1beta1: v1beta1
 spec:
   group: infrastructure.alpininsight.ai
   versions:


### PR DESCRIPTION
## Summary

- Add `status.ready` boolean field to SSHCluster CRD and dual-write it in the controller alongside `status.initialization.provisioned` for KubeadmControlPlane (KCP) compatibility
- Add two RBAC aggregation ClusterRoles (`capi-provider-ssh-aggregated` and `capi-provider-ssh-kcp-aggregated`) so the CAPI and KCP managers can discover and access our CRDs
- Add `cluster.x-k8s.io/v1beta1: v1beta1` contract label to all four CRDs (SSHCluster, SSHHost, SSHMachine, SSHMachineTemplate)
- Fix pre-commit `check-yaml` hook to allow multi-document YAML files

Closes #96

## Test plan

- [x] `uv run pytest python/tests/test_sshcluster.py -v` — all 11 tests pass with new `status.ready` assertions
- [x] `uv run pytest python/tests/ -v` — full suite green (68 passed, 14 skipped)
- [x] `uvx pre-commit run --all-files` — all hooks pass
- [ ] `kubectl apply --dry-run=server` of all CRDs and RBAC in a test cluster