### PR TITLE
chore: resolve CHANGELOG.md merge conflict with main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ci:** Prevent release image loss from concurrency cancellation
 - **ci:** Inherit version bumps from develop on main merge
 - **ci:** Sync changelog workflow from canonical template
-- **capi:** Add status.ready, RBAC aggregation, and CRD contract labels 
+- **capi:** Add status.ready, RBAC aggregation, and CRD contract labels
 
 ### Documentation
 


### PR DESCRIPTION
## Summary

- Merge `origin/main` into `develop` to resolve CHANGELOG.md conflict in release PR #99
- Keeps the develop-side changelog entry for the `fix(capi)` commit

## Test plan

- [x] Only CHANGELOG.md affected — no code changes
- [ ] Verify release PR #99 becomes mergeable after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)