### PR TITLE
docs(external-etcd): fix apiVersion to match served v1beta1 contract

### DIFF
--- a/docs/external-etcd.md
+++ b/docs/external-etcd.md
@@ -81,7 +81,7 @@ on control-plane SSHMachines whose bootstrap data includes a
 ## Example
 
 ```yaml
-apiVersion: infrastructure.alpininsight.ai/v1alpha1
+apiVersion: infrastructure.alpininsight.ai/v1beta1
 kind: SSHMachine
 metadata:
   name: cp-0


### PR DESCRIPTION
## Summary

- Fix example manifest in `docs/external-etcd.md`: change `apiVersion` from `v1alpha1` to `v1beta1` to match the served SSHMachine CRD contract

Addresses reviewer feedback on #99.

## Test plan

- [x] Single-line doc fix — no code changes
- [x] Verified no other `v1alpha1` references exist in the repo