### PR TITLE
fix: asyncssh.wait_for AttributeError in SSH probe and connect

### DIFF
--- a/python/capi_provider_ssh/ssh.py
+++ b/python/capi_provider_ssh/ssh.py
@@ -11,6 +11,7 @@ without breaking the interface.
 
 from __future__ import annotations
 
+import asyncio
 import dataclasses
 import logging
 import os
@@ -78,7 +79,7 @@ class SSHConnection:
         logger.info("SSH execute on %s:%d (timeout=%ds)", self._address, self._port, timeout)
         logger.debug("SSH command: %s", _redact(command))
 
-        result = await asyncssh.wait_for(self._conn.run(command, check=False), timeout=timeout)
+        result = await asyncio.wait_for(self._conn.run(command, check=False), timeout=timeout)
 
         ssh_result = SSHResult(
             exit_code=result.exit_status or 0,
@@ -159,7 +160,7 @@ class SSHClient:
         except asyncssh.KeyImportError as e:
             raise ValueError(f"Failed to parse SSH private key: {e}") from e
 
-        conn = await asyncssh.wait_for(
+        conn = await asyncio.wait_for(
             asyncssh.connect(
                 host=address,
                 port=port,

--- a/python/tests/test_ssh.py
+++ b/python/tests/test_ssh.py
@@ -1,8 +1,12 @@
 """Tests for SSH client wrapper."""
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import asyncssh
 import pytest
 
-from capi_provider_ssh.ssh import SSHResult, _redact
+from capi_provider_ssh.ssh import SSHClient, SSHConnection, SSHResult, _redact
 
 
 class TestSSHResult:
@@ -53,3 +57,66 @@ class TestRedact:
         # appear in logs anyway (the SSH client doesn't log keys)
         result = _redact(text)
         assert result is not None  # Just verify it doesn't crash
+
+
+class TestSSHClient:
+    @pytest.mark.asyncio
+    async def test_connect_uses_asyncio_wait_for(self):
+        raw_conn = MagicMock()
+        connect_call = object()
+        imported_key = object()
+        wait_for_mock = AsyncMock(return_value=raw_conn)
+
+        with (
+            patch("capi_provider_ssh.ssh.asyncssh.import_private_key", return_value=imported_key) as import_key,
+            patch("capi_provider_ssh.ssh.asyncssh.connect", return_value=connect_call) as connect,
+            patch("capi_provider_ssh.ssh.asyncio.wait_for", wait_for_mock),
+        ):
+            conn = await SSHClient.connect(
+                address="10.0.0.1",
+                port=2222,
+                user="admin",
+                key="fake-private-key",
+                timeout=9,
+            )
+
+        assert isinstance(conn, SSHConnection)
+        import_key.assert_called_once_with("fake-private-key")
+        connect.assert_called_once_with(
+            host="10.0.0.1",
+            port=2222,
+            username="admin",
+            client_keys=[imported_key],
+            known_hosts=None,
+        )
+        wait_for_mock.assert_awaited_once_with(connect_call, timeout=9)
+
+    @pytest.mark.asyncio
+    async def test_connect_invalid_private_key_raises_value_error(self):
+        with (
+            patch(
+                "capi_provider_ssh.ssh.asyncssh.import_private_key",
+                side_effect=asyncssh.KeyImportError("bad key"),
+            ),
+            pytest.raises(ValueError, match="Failed to parse SSH private key"),
+        ):
+            await SSHClient.connect(address="10.0.0.1", key="bad-key")
+
+
+class TestSSHConnection:
+    @pytest.mark.asyncio
+    async def test_execute_uses_asyncio_wait_for(self):
+        run_call = object()
+        raw_conn = MagicMock()
+        raw_conn.run.return_value = run_call
+        wait_for_mock = AsyncMock(
+            return_value=SimpleNamespace(exit_status=0, stdout="ok", stderr=""),
+        )
+        conn = SSHConnection(raw_conn, "10.0.0.1", 22)
+
+        with patch("capi_provider_ssh.ssh.asyncio.wait_for", wait_for_mock):
+            result = await conn.execute("echo ok", timeout=5)
+
+        raw_conn.run.assert_called_once_with("echo ok", check=False)
+        wait_for_mock.assert_awaited_once_with(run_call, timeout=5)
+        assert result == SSHResult(exit_code=0, stdout="ok", stderr="")


### PR DESCRIPTION
## Summary
- replace invalid asyncssh.wait_for() calls with asyncio.wait_for() in SSH connect and command execution paths
- add regression tests for SSHClient.connect() and SSHConnection.execute() timeout wrappers
- keep existing controller behavior unchanged while unblocking SSHHost probes and SSHMachine bootstrap

## Testing
- cd python && .venv/bin/ruff check capi_provider_ssh/ssh.py tests/test_ssh.py
- cd python && .venv/bin/pytest tests/test_ssh.py tests/test_sshhost.py tests/test_sshmachine.py -q

Closes #114