### PR TITLE
chore: resolve main merge conflict in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,10 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ci:** Prevent release image loss from concurrency cancellation
 - **ci:** Inherit version bumps from develop on main merge
 - **ci:** Sync changelog workflow from canonical template
-- **capi:** Add status.ready, RBAC aggregation, and CRD contract labels 
-- **ci:** Add workflow_dispatch and branch guard for releases 
-- **ci:** Replace branch guard with canonical org template 
-- **ci:** Expand branch guard to all conventional commit prefixes 
+- **capi:** Add status.ready, RBAC aggregation, and CRD contract labels
+- **ci:** Add workflow_dispatch and branch guard for releases
+- **ci:** Replace branch guard with canonical org template
+- **ci:** Expand branch guard to all conventional commit prefixes
 - **ssh:** Use asyncio.wait_for for asyncssh operations
 
 ### Documentation
@@ -53,7 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add RBAC requirements and external etcd contract documentation
 - **external-etcd:** Fix missing ClusterConfiguration behavior description
 - Fix minor documentation inaccuracies 
-- **external-etcd:** Fix apiVersion to match served v1beta1 contract 
+- **external-etcd:** Fix apiVersion to match served v1beta1 contract
 
 ### Features
 


### PR DESCRIPTION
## Summary
- merge main into develop to resolve the conflict blocking PR #117
- resolve CHANGELOG.md conflict by keeping both existing release notes and deduplicating entries

## Scope
- no runtime/controller code changes
- changelog-only conflict resolution

## Why
- unblocks develop -> main release promotion PR #117