### PR TITLE
fix: support cloud-init bootstrap and periodic SSHMachine reconcile

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,5 +1,9 @@
 # Roadmap
 
+## Active Fix Plans
+
+- [Issue #119: Cloud-init bootstrap compatibility + SSHMachine reconcile reliability](roadmap/issue-119-bootstrap-cloud-init-and-reconcile-plan.md)
+
 ## Current Capabilities (v0.3.x)
 
 | Feature | Status |

--- a/docs/roadmap/issue-119-bootstrap-cloud-init-and-reconcile-plan.md
+++ b/docs/roadmap/issue-119-bootstrap-cloud-init-and-reconcile-plan.md
@@ -1,0 +1,191 @@
+# Issue #119 Design Plan: Cloud-Init Bootstrap Compatibility + Reconcile Reliability
+
+Issue: [#119](https://github.com/alpininsight/capi-provider-ssh/issues/119)
+
+## Problem Summary
+
+The SSHMachine controller currently assumes bootstrap data is a shell script and executes it directly as `/tmp/bootstrap.sh`. In production CAPI flows, bootstrap data is commonly cloud-init (`#cloud-config`), which fails when executed as bash.
+
+Issue #119 also highlights a reliability gap: reconciliation can be missed when `ownerReferences` are not present at first creation event and no later event re-triggers reconciliation.
+
+## Goals
+
+1. Make bootstrap execution format-aware (`cloud-config` and shell).
+2. Preserve existing shell-script bootstrap behavior.
+3. Keep external etcd wiring compatible with both bootstrap formats.
+4. Add periodic SSHMachine reconciliation so missed create/update events recover automatically.
+5. Add focused regression tests for both failures from issue #119.
+
+## Non-Goals
+
+1. Adding host-side `cloud-init` as a runtime dependency.
+2. Supporting every cloud-init module; only modules required by kubeadm bootstrap output and current provider behavior.
+3. Changing CRD schema for this fix.
+
+## Design Decisions
+
+1. Provider-side execution normalization:
+   - Detect bootstrap payload format.
+   - Convert supported cloud-init payload to executable shell before upload.
+   - Execute one deterministic rendered script remotely.
+2. Keep controller behavior idempotent:
+   - Preserve existing `providerID`/`initialization.provisioned` checks.
+   - Reuse current status/failure fields.
+3. Add timer-driven reconcile for SSHMachine:
+   - Retry non-ready machines at fixed interval.
+   - Reuse existing reconcile logic rather than duplicating behavior.
+
+## Atomic Implementation Slices
+
+### Slice 1: Bootstrap Format Detection and Parsing Primitives
+
+Files:
+- `python/capi_provider_ssh/controllers/sshmachine.py`
+
+Changes:
+1. Add format detector:
+   - `cloud-config` if a non-empty line starts with `#cloud-config` (allow optional leading `## template: jinja`).
+   - `shell` if first non-empty line starts with shebang (`#!`) or fallback shell heuristic.
+   - `unknown` otherwise.
+2. Add parser helper for cloud-init YAML with schema validation for:
+   - `write_files` (list of mappings)
+   - `runcmd` (list of commands)
+3. Add explicit failure mapping:
+   - Unsupported/invalid bootstrap format -> `PermanentError` with status reason `BootstrapFormatError`.
+
+Acceptance criteria:
+1. Controller can classify cloud-init and shell inputs deterministically.
+2. Invalid/unknown format fails with actionable status message.
+
+### Slice 2: Cloud-Init -> Shell Renderer
+
+Files:
+- `python/capi_provider_ssh/controllers/sshmachine.py`
+
+Changes:
+1. Implement renderer that converts parsed cloud-init to shell:
+   - `write_files`: create directories, write file content via quoted heredoc, apply permissions/owner if present.
+   - `runcmd`: support string and list form commands.
+2. Support expected encodings for `write_files.content`:
+   - plain text
+   - base64 (`encoding: b64`/`base64`)
+3. Emit deterministic script with strict shell options (`set -euo pipefail`).
+
+Acceptance criteria:
+1. Rendered script is executable with current SSH execution path.
+2. File payloads and command order from cloud-init are preserved.
+
+### Slice 3: Reconcile Integration + External Etcd Compatibility
+
+Files:
+- `python/capi_provider_ssh/controllers/sshmachine.py`
+
+Changes:
+1. Before upload, normalize bootstrap payload:
+   - shell input -> pass through
+   - cloud-init input -> render to shell
+2. External etcd patching:
+   - Keep existing shell heredoc patch path.
+   - Add cloud-init patch path by modifying kubeadm `ClusterConfiguration` content inside `write_files` entries for kubeadm YAML files.
+3. Add explicit bootstrap-format logging (`shell` vs `cloud-config`) without leaking secrets.
+
+Acceptance criteria:
+1. Existing shell bootstrap tests remain green.
+2. Cloud-init bootstrap succeeds through same SSH upload/execute interface.
+3. External etcd injection works for both formats.
+
+### Slice 4: Timer-Based Reconcile for SSHMachine
+
+Files:
+- `python/capi_provider_ssh/controllers/sshmachine.py`
+- `python/capi_provider_ssh/main.py` (optional env naming cleanup only if needed)
+- `python/deploy/deployment.yaml` (if introducing dedicated interval variable)
+
+Changes:
+1. Add `@kopf.timer` for `sshmachines` with interval default (for example 60s).
+2. Refactor reconcile body into shared internal function used by:
+   - create handler
+   - update handler
+   - timer handler
+3. Timer guardrails:
+   - skip paused objects
+   - skip already-provisioned objects
+   - retry objects waiting for owner, bootstrap data, or transient SSH errors
+
+Acceptance criteria:
+1. Missing initial event no longer leaves SSHMachine permanently stuck.
+2. No behavioral regression for normal create/update-triggered reconciliation.
+
+### Slice 5: Unit + Integration Test Expansion
+
+Files:
+- `python/tests/test_sshmachine.py`
+- `python/tests/integration/conftest.py`
+- `python/tests/integration/test_sshmachine_integration.py`
+
+Changes:
+1. Add unit tests for bootstrap normalization:
+   - cloud-init with `write_files` + `runcmd` renders and executes successfully
+   - invalid cloud-init structure returns `BootstrapFormatError`
+   - shell format remains unchanged
+2. Add unit tests for cloud-init + external etcd patch path.
+3. Add timer-reconcile tests:
+   - waiting-for-owner state recovered when owner appears later
+   - provisioned machine skipped by timer
+4. Change integration bootstrap fixture to cloud-init representative payload.
+
+Acceptance criteria:
+1. Tests fail on old behavior and pass with new implementation.
+2. Regressions for issue #119 are permanently covered.
+
+### Slice 6: Docs and Release Notes
+
+Files:
+- `README.md`
+- `docs/architecture.md`
+- `docs/faq.md`
+- `CHANGELOG.md`
+
+Changes:
+1. Document bootstrap format support and controller behavior.
+2. Add troubleshooting entry for bootstrap format mismatch symptoms.
+3. Record fix in changelog.
+
+Acceptance criteria:
+1. Operator-facing docs clearly describe expected bootstrap formats and fallback behavior.
+
+## Test Matrix
+
+1. Static checks:
+   - `cd python && .venv/bin/ruff check .`
+2. Focused unit tests:
+   - `cd python && .venv/bin/pytest tests/test_sshmachine.py -q`
+3. SSH wrapper/controller safety checks:
+   - `cd python && .venv/bin/pytest tests/test_ssh.py tests/test_sshhost.py -q`
+4. Integration tests (when environment is available):
+   - `cd python && INTEGRATION_TESTS=1 .venv/bin/pytest -m integration -q`
+
+## Rollout Strategy
+
+1. Merge feature PR to `develop`.
+2. Run management-cluster canary validation:
+   - verify a fresh SSHMachine with cloud-init bootstrap reaches `provisioned=true`
+   - verify timer retries non-ready SSHMachine without manual annotation nudge
+3. Promote `develop -> main` release PR.
+4. Validate published image and release tag.
+
+## Risks and Mitigations
+
+1. Risk: cloud-init parsing misses uncommon kubeadm output shape.
+   - Mitigation: strict validation + explicit error reason + fixture based on real bootstrap secret samples.
+2. Risk: timer introduces duplicate reconcile attempts.
+   - Mitigation: shared idempotency checks and timer guardrails.
+3. Risk: external etcd patching diverges between formats.
+   - Mitigation: single semantic patch target (`ClusterConfiguration`) with format-specific adapters and dedicated tests.
+
+## Definition of Done
+
+1. Issue #119 reproduction no longer fails with `write_files: command not found`.
+2. SSHMachine eventually reconciles after missed ownerReference timing windows.
+3. Unit + integration coverage includes cloud-init bootstrap and timer retry scenarios.
+4. Docs and changelog updated.

--- a/python/capi_provider_ssh/controllers/sshmachine.py
+++ b/python/capi_provider_ssh/controllers/sshmachine.py
@@ -10,6 +10,7 @@ This is the core controller of the provider. It handles:
 import base64
 import datetime
 import logging
+import os
 import posixpath
 import re
 import shlex
@@ -26,6 +27,9 @@ logger = logging.getLogger(__name__)
 DEFAULT_EXTERNAL_ETCD_CA_FILE = "/etc/kubernetes/pki/etcd-external/ca.crt"
 DEFAULT_EXTERNAL_ETCD_CERT_FILE = "/etc/kubernetes/pki/etcd-external/client.crt"
 DEFAULT_EXTERNAL_ETCD_KEY_FILE = "/etc/kubernetes/pki/etcd-external/client.key"
+SSHMACHINE_RECONCILE_INTERVAL = int(
+    os.environ.get("SSHMACHINE_RECONCILE_INTERVAL", os.environ.get("RECONCILE_INTERVAL", "60")),
+)
 
 
 def _now_iso() -> str:
@@ -237,6 +241,184 @@ def _patch_external_etcd_in_kubeadm_yaml(yaml_text: str, external_etcd: dict) ->
     return rendered, saw_cluster_configuration, True
 
 
+def _detect_bootstrap_format(bootstrap_data: str) -> str:
+    """Detect bootstrap payload format (cloud-config or shell)."""
+    for line in bootstrap_data.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        # kubeadm cloud-init commonly carries a leading template marker.
+        if stripped.startswith("## template:"):
+            continue
+        if stripped.startswith("#cloud-config") or stripped.startswith(("write_files:", "runcmd:")):
+            return "cloud-config"
+        if stripped.startswith("#!"):
+            return "shell"
+        return "shell"
+    return "unknown"
+
+
+def _parse_cloud_config(bootstrap_data: str) -> dict:
+    """Parse and validate a cloud-config payload."""
+    try:
+        config = yaml.safe_load(bootstrap_data) or {}
+    except yaml.YAMLError as e:
+        raise kopf.PermanentError(f"bootstrap cloud-config YAML is invalid: {e}") from e
+
+    if not isinstance(config, dict):
+        raise kopf.PermanentError("bootstrap cloud-config must be a mapping")
+
+    write_files = config.get("write_files", [])
+    if write_files is None:
+        write_files = []
+    if not isinstance(write_files, list):
+        raise kopf.PermanentError("bootstrap cloud-config write_files must be a list")
+    for idx, entry in enumerate(write_files):
+        if not isinstance(entry, dict):
+            raise kopf.PermanentError(f"bootstrap cloud-config write_files[{idx}] must be an object")
+        path = entry.get("path")
+        if not isinstance(path, str) or not path:
+            raise kopf.PermanentError(
+                f"bootstrap cloud-config write_files[{idx}].path must be a non-empty string",
+            )
+
+    runcmd = config.get("runcmd", [])
+    if runcmd is None:
+        runcmd = []
+    if not isinstance(runcmd, list):
+        raise kopf.PermanentError("bootstrap cloud-config runcmd must be a list")
+    for idx, command in enumerate(runcmd):
+        if isinstance(command, str):
+            continue
+        if isinstance(command, list):
+            if not all(isinstance(part, (str, int, float, bool)) for part in command):
+                raise kopf.PermanentError(
+                    f"bootstrap cloud-config runcmd[{idx}] list entries must be scalar values",
+                )
+            continue
+        raise kopf.PermanentError(f"bootstrap cloud-config runcmd[{idx}] must be string or list")
+
+    config["write_files"] = write_files
+    config["runcmd"] = runcmd
+    return config
+
+
+def _decode_cloud_write_file_content(entry: dict, index: int) -> str:
+    """Read write_files entry content, decoding supported encodings."""
+    content = entry.get("content", "")
+    if content is None:
+        content = ""
+    if not isinstance(content, str):
+        raise kopf.PermanentError(
+            f"bootstrap cloud-config write_files[{index}].content must be a string when set",
+        )
+
+    encoding = entry.get("encoding")
+    if encoding is None:
+        return content
+    if not isinstance(encoding, str):
+        raise kopf.PermanentError(
+            f"bootstrap cloud-config write_files[{index}].encoding must be a string when set",
+        )
+
+    normalized = encoding.strip().lower()
+    if normalized in {"", "text", "plain"}:
+        return content
+    if normalized in {"b64", "base64"}:
+        try:
+            return base64.b64decode(content).decode("utf-8")
+        except Exception as e:
+            raise kopf.PermanentError(
+                f"bootstrap cloud-config write_files[{index}] has invalid base64 content: {e}",
+            ) from e
+
+    raise kopf.PermanentError(
+        f"bootstrap cloud-config write_files[{index}] encoding '{encoding}' is unsupported",
+    )
+
+
+def _store_cloud_write_file_content(entry: dict, text: str) -> None:
+    """Write file content back to write_files, preserving encoding convention."""
+    encoding = entry.get("encoding")
+    if isinstance(encoding, str) and encoding.strip().lower() in {"b64", "base64"}:
+        entry["content"] = base64.b64encode(text.encode("utf-8")).decode("utf-8")
+        return
+    entry["content"] = text
+
+
+def _format_cloud_file_mode(mode: int | str, index: int) -> str:
+    """Normalize cloud-init file mode value into chmod-compatible text."""
+    if isinstance(mode, int):
+        return format(mode, "o")
+    if isinstance(mode, str):
+        normalized = mode.strip().strip("'\"")
+        if normalized:
+            return normalized
+    raise kopf.PermanentError(
+        f"bootstrap cloud-config write_files[{index}].permissions must be a non-empty string or integer",
+    )
+
+
+def _render_cloud_config_to_shell(bootstrap_data: str) -> str:
+    """Render supported cloud-config primitives into an executable shell script."""
+    config = _parse_cloud_config(bootstrap_data)
+    lines = [
+        "#!/bin/bash",
+        "set -euo pipefail",
+    ]
+
+    write_files = config.get("write_files", [])
+    for idx, entry in enumerate(write_files):
+        path = entry["path"]
+        directory = posixpath.dirname(path) or "/"
+        lines.append(f"install -d -m 0755 {shlex.quote(directory)}")
+
+        marker = f"__CAPI_BOOTSTRAP_FILE_{idx}__"
+        content = _decode_cloud_write_file_content(entry, idx)
+        lines.append(f"cat <<'{marker}' > {shlex.quote(path)}")
+        if content:
+            lines.extend(content.splitlines())
+        lines.append(marker)
+
+        permissions = entry.get("permissions")
+        if permissions is not None:
+            lines.append(f"chmod {shlex.quote(_format_cloud_file_mode(permissions, idx))} {shlex.quote(path)}")
+
+        owner = entry.get("owner")
+        if owner is not None:
+            if not isinstance(owner, str) or not owner:
+                raise kopf.PermanentError(
+                    f"bootstrap cloud-config write_files[{idx}].owner must be a non-empty string",
+                )
+            lines.append(f"chown {shlex.quote(owner)} {shlex.quote(path)}")
+
+    for idx, command in enumerate(config.get("runcmd", [])):
+        if isinstance(command, str):
+            lines.append(command)
+            continue
+        if not command:
+            continue
+        rendered = " ".join(shlex.quote(str(part)) for part in command)
+        if not rendered:
+            raise kopf.PermanentError(f"bootstrap cloud-config runcmd[{idx}] cannot be empty")
+        lines.append(rendered)
+
+    rendered_script = "\n".join(lines).rstrip("\n")
+    return f"{rendered_script}\n"
+
+
+def _prepare_bootstrap_script(bootstrap_data: str) -> tuple[str, str]:
+    """Normalize bootstrap payload to an executable shell script."""
+    bootstrap_format = _detect_bootstrap_format(bootstrap_data)
+    if bootstrap_format == "cloud-config":
+        return _render_cloud_config_to_shell(bootstrap_data), bootstrap_format
+    if bootstrap_format == "shell":
+        if not bootstrap_data.strip():
+            raise kopf.PermanentError("bootstrap data is empty")
+        return bootstrap_data, bootstrap_format
+    raise kopf.PermanentError("bootstrap data format is not supported")
+
+
 def _parse_heredoc_start(line: str) -> tuple[str, str] | None:
     """Parse shell heredoc forms used for writing files in bootstrap scripts."""
     direct = re.match(r'^\s*cat\s+>\s*(?P<path>\S+)\s+<<\s*["\']?(?P<tag>[A-Za-z_][A-Za-z0-9_]*)["\']?\s*$', line)
@@ -250,8 +432,8 @@ def _parse_heredoc_start(line: str) -> tuple[str, str] | None:
     return None
 
 
-def _inject_external_etcd_into_bootstrap_data(bootstrap_data: str, external_etcd: dict) -> tuple[str, bool]:
-    """Inject external etcd wiring into kubeadm ClusterConfiguration heredocs."""
+def _inject_external_etcd_into_shell_bootstrap_data(bootstrap_data: str, external_etcd: dict) -> tuple[str, bool]:
+    """Inject external etcd wiring into shell bootstrap kubeadm heredocs."""
     lines = bootstrap_data.splitlines()
     output: list[str] = []
     idx = 0
@@ -300,6 +482,47 @@ def _inject_external_etcd_into_bootstrap_data(bootstrap_data: str, external_etcd
     if bootstrap_data.endswith("\n"):
         rendered += "\n"
     return rendered, changed_any
+
+
+def _inject_external_etcd_into_cloud_config_bootstrap_data(
+    bootstrap_data: str,
+    external_etcd: dict,
+) -> tuple[str, bool]:
+    """Inject external etcd wiring into cloud-config write_files kubeadm payloads."""
+    config = _parse_cloud_config(bootstrap_data)
+    write_files = config.get("write_files", [])
+
+    saw_cluster_configuration = False
+    changed_any = False
+    for idx, entry in enumerate(write_files):
+        path = entry.get("path")
+        if not isinstance(path, str) or "kubeadm" not in path or not path.endswith((".yaml", ".yml")):
+            continue
+
+        content = _decode_cloud_write_file_content(entry, idx)
+        patched_text, saw_here, changed_here = _patch_external_etcd_in_kubeadm_yaml(content, external_etcd)
+        saw_cluster_configuration = saw_cluster_configuration or saw_here
+        changed_any = changed_any or changed_here
+        if saw_here:
+            _store_cloud_write_file_content(entry, patched_text)
+
+    if not saw_cluster_configuration:
+        raise kopf.PermanentError(
+            "externalEtcd is configured but bootstrap data has no kubeadm ClusterConfiguration to wire",
+        )
+
+    rendered = "#cloud-config\n" + yaml.safe_dump(config, sort_keys=False).rstrip("\n")
+    if bootstrap_data.endswith("\n"):
+        rendered += "\n"
+    return rendered, changed_any
+
+
+def _inject_external_etcd_into_bootstrap_data(bootstrap_data: str, external_etcd: dict) -> tuple[str, bool]:
+    """Inject external etcd wiring into shell or cloud-config bootstrap payload."""
+    bootstrap_format = _detect_bootstrap_format(bootstrap_data)
+    if bootstrap_format == "cloud-config":
+        return _inject_external_etcd_into_cloud_config_bootstrap_data(bootstrap_data, external_etcd)
+    return _inject_external_etcd_into_shell_bootstrap_data(bootstrap_data, external_etcd)
 
 
 async def _upload_external_etcd_certs(conn, namespace: str, external_etcd: dict) -> None:
@@ -723,6 +946,18 @@ async def sshmachine_reconcile(spec, status, name, namespace, meta, patch, **_kw
             ]
             raise
 
+    try:
+        bootstrap_script, bootstrap_format = _prepare_bootstrap_script(bootstrap_data)
+    except kopf.PermanentError as e:
+        patch.status["failureReason"] = "BootstrapFormatError"
+        patch.status["failureMessage"] = str(e)
+        patch.status["conditions"] = [
+            _not_ready_condition("BootstrapFormatError", str(e)),
+        ]
+        raise
+
+    logger.info("SSHMachine %s/%s bootstrap payload format: %s", namespace, name, bootstrap_format)
+
     # Read SSH key -- use patched sshKeyRef if set by host claim, otherwise from spec
     ssh_key_ref = patch.spec.get("sshKeyRef", spec.get("sshKeyRef", {}))
     secret_name = ssh_key_ref.get("name")
@@ -795,7 +1030,7 @@ async def sshmachine_reconcile(spec, status, name, namespace, meta, patch, **_kw
                     raise
 
             # Upload bootstrap script
-            await conn.upload(bootstrap_data, "/tmp/bootstrap.sh")  # noqa: S108
+            await conn.upload(bootstrap_script, "/tmp/bootstrap.sh")  # noqa: S108
 
             # Execute bootstrap
             result = await conn.execute("chmod +x /tmp/bootstrap.sh && /tmp/bootstrap.sh")  # noqa: S108
@@ -841,6 +1076,25 @@ async def sshmachine_reconcile(spec, status, name, namespace, meta, patch, **_kw
     patch.status["failureMessage"] = None
 
     logger.info("SSHMachine %s/%s provisioned: providerID=%s", namespace, name, provider_id)
+
+
+@kopf.timer(
+    API_GROUP,
+    API_VERSION,
+    "sshmachines",
+    interval=SSHMACHINE_RECONCILE_INTERVAL,
+    initial_delay=15,
+)
+async def sshmachine_reconcile_timer(spec, status, name, namespace, meta, patch, **_kwargs):
+    """Periodic reconcile to recover from missed create/update event races."""
+    await sshmachine_reconcile(
+        spec=spec,
+        status=status,
+        name=name,
+        namespace=namespace,
+        meta=meta,
+        patch=patch,
+    )
 
 
 @kopf.on.delete(API_GROUP, API_VERSION, "sshmachines")

--- a/python/tests/integration/conftest.py
+++ b/python/tests/integration/conftest.py
@@ -110,7 +110,17 @@ def ssh_key_secret(core_api, test_namespace):
 @pytest.fixture
 def bootstrap_secret(core_api, test_namespace):
     """Create a bootstrap data Secret (simulates what kubeadm bootstrap provider creates)."""
-    bootstrap_data = "#!/bin/bash\necho 'bootstrap test'"
+    bootstrap_data = """## template: jinja
+#cloud-config
+write_files:
+- path: /etc/kubernetes/bootstrap-marker
+  owner: root:root
+  permissions: '0644'
+  content: |
+    marker=true
+runcmd:
+- echo bootstrap test
+"""
     secret = kubernetes.client.V1Secret(
         metadata=kubernetes.client.V1ObjectMeta(name="test-bootstrap-data", namespace=test_namespace),
         data={"value": base64.b64encode(bootstrap_data.encode()).decode()},

--- a/python/tests/test_sshmachine.py
+++ b/python/tests/test_sshmachine.py
@@ -7,14 +7,17 @@ import pytest
 
 from capi_provider_ssh.controllers.sshmachine import (
     _choose_host,
+    _detect_bootstrap_format,
     _has_machine_owner,
     _inject_external_etcd_into_bootstrap_data,
     _is_already_provisioned,
     _normalize_external_etcd,
+    _prepare_bootstrap_script,
     _release_host,
     sshmachine_delete,
     sshmachine_reboot,
     sshmachine_reconcile,
+    sshmachine_reconcile_timer,
 )
 from capi_provider_ssh.ssh import SSHResult
 
@@ -214,6 +217,129 @@ class TestSSHMachineReconcile:
                     patch=patch_obj,
                 )
             assert patch_obj["status"]["failureReason"] == "BootstrapFailed"
+
+    @pytest.mark.asyncio
+    async def test_successful_bootstrap_with_cloud_config(self, sshmachine_spec, sshmachine_meta_with_owner):
+        cloud_config_bootstrap = """## template: jinja
+#cloud-config
+write_files:
+- path: /etc/kubernetes/bootstrap-marker
+  owner: root:root
+  permissions: '0644'
+  content: |
+    marker=true
+runcmd:
+- echo bootstrap
+- [kubeadm, join, 10.0.0.1:6443]
+"""
+        mock_conn = AsyncMock()
+        mock_conn.execute.return_value = SSHResult(exit_code=0, stdout="ok", stderr="")
+        mock_conn.upload = AsyncMock()
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "capi_provider_ssh.controllers.sshmachine._read_bootstrap_data",
+                new_callable=AsyncMock,
+                return_value=cloud_config_bootstrap,
+            ),
+            patch(
+                "capi_provider_ssh.controllers.sshmachine._read_ssh_key",
+                new_callable=AsyncMock,
+                return_value="fake-key",
+            ),
+            patch(
+                "capi_provider_ssh.controllers.sshmachine.SSHClient.connect",
+                new_callable=AsyncMock,
+                return_value=mock_conn,
+            ),
+        ):
+            patch_obj = kopf.Patch({})
+            await sshmachine_reconcile(
+                spec=sshmachine_spec,
+                status={},
+                name="m1",
+                namespace="default",
+                meta=sshmachine_meta_with_owner,
+                patch=patch_obj,
+            )
+
+        uploaded_script = mock_conn.upload.call_args[0][0]
+        assert "#cloud-config" not in uploaded_script
+        assert "cat <<'__CAPI_BOOTSTRAP_FILE_0__' > /etc/kubernetes/bootstrap-marker" in uploaded_script
+        assert "kubeadm join 10.0.0.1:6443" in uploaded_script
+        assert patch_obj["status"]["initialization"]["provisioned"] is True
+
+    @pytest.mark.asyncio
+    async def test_timer_recovers_after_owner_reference_appears(self, sshmachine_spec, sshmachine_meta_with_owner):
+        waiting_patch = kopf.Patch({})
+        await sshmachine_reconcile(
+            spec=sshmachine_spec,
+            status={},
+            name="m1",
+            namespace="default",
+            meta={},
+            patch=waiting_patch,
+        )
+        assert waiting_patch["status"]["conditions"][0]["reason"] == "WaitingForMachineOwner"
+
+        mock_conn = AsyncMock()
+        mock_conn.execute.return_value = SSHResult(exit_code=0, stdout="ok", stderr="")
+        mock_conn.upload = AsyncMock()
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "capi_provider_ssh.controllers.sshmachine._read_bootstrap_data",
+                new_callable=AsyncMock,
+                return_value="#!/bin/bash\necho bootstrap",
+            ),
+            patch(
+                "capi_provider_ssh.controllers.sshmachine._read_ssh_key",
+                new_callable=AsyncMock,
+                return_value="fake-key",
+            ),
+            patch(
+                "capi_provider_ssh.controllers.sshmachine.SSHClient.connect",
+                new_callable=AsyncMock,
+                return_value=mock_conn,
+            ),
+        ):
+            recover_patch = kopf.Patch({})
+            await sshmachine_reconcile_timer(
+                spec=sshmachine_spec,
+                status=waiting_patch.get("status", {}),
+                name="m1",
+                namespace="default",
+                meta=sshmachine_meta_with_owner,
+                patch=recover_patch,
+            )
+
+        assert recover_patch["status"]["initialization"]["provisioned"] is True
+        assert recover_patch["spec"]["providerID"] == "ssh://100.64.0.10"
+
+    @pytest.mark.asyncio
+    async def test_timer_skips_already_provisioned_machine(self, sshmachine_spec, sshmachine_meta_with_owner):
+        status = {
+            "initialization": {"provisioned": True},
+            "conditions": [{"type": "Ready", "status": "True"}],
+        }
+        with patch(
+            "capi_provider_ssh.controllers.sshmachine._read_bootstrap_data",
+            new_callable=AsyncMock,
+        ) as read_bootstrap:
+            patch_obj = kopf.Patch({})
+            await sshmachine_reconcile_timer(
+                spec=sshmachine_spec,
+                status=status,
+                name="m1",
+                namespace="default",
+                meta=sshmachine_meta_with_owner,
+                patch=patch_obj,
+            )
+        read_bootstrap.assert_not_called()
 
 
 class TestSSHMachineDryRun:
@@ -731,6 +857,32 @@ class TestExternalEtcdConfig:
         with pytest.raises(kopf.PermanentError, match="externalEtcd.endpoints"):
             _normalize_external_etcd(spec)
 
+    def test_detect_bootstrap_format_cloud_config(self):
+        bootstrap = """## template: jinja
+#cloud-config
+runcmd:
+- echo ok
+"""
+        assert _detect_bootstrap_format(bootstrap) == "cloud-config"
+
+    def test_prepare_bootstrap_script_renders_cloud_config(self):
+        bootstrap = """#cloud-config
+write_files:
+- path: /etc/kubernetes/bootstrap-marker
+  owner: root:root
+  permissions: '0644'
+  content: |
+    marker=true
+runcmd:
+- [echo, bootstrap]
+"""
+        script, bootstrap_format = _prepare_bootstrap_script(bootstrap)
+        assert bootstrap_format == "cloud-config"
+        assert "cat <<'__CAPI_BOOTSTRAP_FILE_0__' > /etc/kubernetes/bootstrap-marker" in script
+        assert "chmod 0644 /etc/kubernetes/bootstrap-marker" in script
+        assert "chown root:root /etc/kubernetes/bootstrap-marker" in script
+        assert "echo bootstrap" in script
+
     def test_inject_external_etcd_into_bootstrap_data(self):
         bootstrap = """#!/bin/bash
 cat > /run/kubeadm/kubeadm.yaml <<'EOF'
@@ -758,6 +910,36 @@ kubeadm init --config /run/kubeadm/kubeadm.yaml
         assert "etcd-cafile: /etc/kubernetes/pki/etcd-external/ca.crt" in patched
         assert "etcd-certfile: /etc/kubernetes/pki/etcd-external/client.crt" in patched
         assert "etcd-keyfile: /etc/kubernetes/pki/etcd-external/client.key" in patched
+
+    def test_inject_external_etcd_into_cloud_config_bootstrap_data(self):
+        bootstrap = """#cloud-config
+write_files:
+- path: /run/kubeadm/kubeadm.yaml
+  owner: root:root
+  permissions: '0600'
+  content: |
+    apiVersion: kubeadm.k8s.io/v1beta4
+    kind: ClusterConfiguration
+    apiServer:
+      extraArgs: {}
+    ---
+    apiVersion: kubeadm.k8s.io/v1beta4
+    kind: InitConfiguration
+    nodeRegistration:
+      name: cp-0
+runcmd:
+- kubeadm init --config /run/kubeadm/kubeadm.yaml
+"""
+        external = {
+            "servers": "https://10.0.0.10:2379,https://10.0.0.11:2379",
+            "ca_file": "/etc/kubernetes/pki/etcd-external/ca.crt",
+            "cert_file": "/etc/kubernetes/pki/etcd-external/client.crt",
+            "key_file": "/etc/kubernetes/pki/etcd-external/client.key",
+        }
+        patched, changed = _inject_external_etcd_into_bootstrap_data(bootstrap, external)
+        assert changed is True
+        assert patched.startswith("#cloud-config")
+        assert "etcd-servers: https://10.0.0.10:2379,https://10.0.0.11:2379" in patched
 
     def test_inject_external_etcd_requires_cluster_configuration(self):
         bootstrap = """#!/bin/bash


### PR DESCRIPTION
## Summary
- add bootstrap format detection and cloud-config to shell rendering for SSHMachine provisioning
- keep shell bootstrap behavior and extend external etcd wiring to cloud-config payloads
- add periodic SSHMachine timer reconcile to recover from missed ownerReference timing windows
- add unit and integration fixture coverage for cloud-config bootstrap and timer recovery
- add roadmap issue plan link and detailed design plan document

## Testing
- cd python && .venv/bin/ruff check capi_provider_ssh/controllers/sshmachine.py tests/test_sshmachine.py tests/integration/conftest.py
- cd python && .venv/bin/pytest tests/test_sshmachine.py tests/test_ssh.py tests/test_sshhost.py -q
- cd python && .venv/bin/pytest tests/integration/test_sshmachine_integration.py -q

Closes #119