### PR TITLE
test: deterministic teardown contract for integration namespaces

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -48,6 +48,8 @@ jobs:
         run: uv run ruff format --check capi_provider_ssh tests
 
       - name: Pytest with coverage
+        env:
+          TEARDOWN_ARTIFACT_DIR: ${{ github.workspace }}/python/test-artifacts/teardown
         run: uv run pytest -q --cov=capi_provider_ssh --cov-report=term-missing --cov-report=xml
 
       - name: Upload Python coverage artifact
@@ -56,6 +58,14 @@ jobs:
         with:
           name: python-coverage
           path: python/coverage.xml
+          if-no-files-found: ignore
+
+      - name: Upload teardown debug artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: teardown-debug-artifacts
+          path: python/test-artifacts/teardown
           if-no-files-found: ignore
 
   manifests:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -98,6 +98,23 @@ New releases are cut automatically when `develop` is merged into `main`. Check
 the [Releases page](https://github.com/alpininsight/capi-provider-ssh/releases)
 for the latest stable tag.
 
+## How does integration test teardown avoid leaked test namespaces?
+
+Integration tests now use a deterministic teardown contract in
+`python/tests/integration/cleanup.py`:
+
+1. Teardown is allowed only for namespaces with prefix `test-capi-ssh-` and
+   label `capi-provider-ssh-test=true`.
+2. Resources are deleted in explicit order (`SSHMachine`/`SSHCluster` first,
+   then CAPI/Bootstrap test objects, then namespace).
+3. Teardown asserts there is no residue (`Machine`, `SSHMachine`,
+   `KubeadmConfig`, test Secrets, test namespaces).
+4. On teardown failure, a debug bundle is written (when
+   `TEARDOWN_ARTIFACT_DIR` is set) and uploaded by CI.
+
+This is designed to prevent recurring `test-cluster not found` noise from
+orphaned test resources.
+
 ## Can I swap DNS so staging becomes production and keep old production as backup?
 
 **Yes.** This is a valid blue/green-style cutover pattern:

--- a/docs/live-rollout-validation.md
+++ b/docs/live-rollout-validation.md
@@ -99,6 +99,11 @@ kubectl -n <namespace> delete cluster <canary-cluster>
 # Verify cleanup (finalizers + host release)
 kubectl -n <namespace> get machines,sshmachines
 kubectl -n <namespace> get sshhosts -o custom-columns='NAME:.metadata.name,CONSUMER:.spec.consumerRef.name'
+
+# Verify no leaked integration test namespaces/resources remain
+kubectl get ns | rg '^test-capi-ssh-' || true
+kubectl get machines.cluster.x-k8s.io -A | rg 'test-capi-ssh' || true
+kubectl get sshmachines.infrastructure.alpininsight.ai -A | rg 'test-capi-ssh' || true
 ```
 
 Git-first durable teardown (preferred):
@@ -116,6 +121,7 @@ flux -n flux-system reconcile kustomization capi-clusters --with-source
 Expected teardown outcome:
 - Canary `Machine`/`SSHMachine` objects are removed.
 - Claimed `SSHHost` entries have empty `consumerRef`.
+- No `test-capi-ssh-*` residue remains after integration teardown checks.
 
 ## Phase 4: Promote Full Rollout
 

--- a/python/tests/integration/cleanup.py
+++ b/python/tests/integration/cleanup.py
@@ -1,0 +1,429 @@
+"""Deterministic teardown helpers for integration test namespaces."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import kubernetes
+
+TEST_NAMESPACE_PREFIX = "test-capi-ssh-"
+TEST_NAMESPACE_LABEL_KEY = "capi-provider-ssh-test"
+TEST_NAMESPACE_LABEL_VALUE = "true"
+
+SSH_API_GROUP = "infrastructure.alpininsight.ai"
+SSH_API_VERSION = "v1beta1"
+
+CAPI_API_GROUP = "cluster.x-k8s.io"
+CAPI_API_VERSION = "v1beta1"
+
+BOOTSTRAP_API_GROUP = "bootstrap.cluster.x-k8s.io"
+BOOTSTRAP_API_VERSION = "v1beta1"
+
+
+@dataclass(frozen=True)
+class TeardownConfig:
+    """Runtime configuration for integration teardown."""
+
+    soft_timeout_seconds: float = 60.0
+    hard_timeout_seconds: float = 180.0
+    poll_interval_seconds: float = 2.0
+    artifact_dir: Path | None = None
+
+
+@dataclass
+class TeardownReport:
+    """Summary of teardown execution."""
+
+    namespace: str
+    deleted_resources: dict[str, int]
+    remediated_finalizers: int
+    duration_seconds: float
+    debug_bundle_path: str | None = None
+
+
+def is_test_namespace(name: str, labels: dict[str, str] | None) -> bool:
+    """Return True when namespace is eligible for test teardown operations."""
+    if not name.startswith(TEST_NAMESPACE_PREFIX):
+        return False
+    if not labels:
+        return False
+    return labels.get(TEST_NAMESPACE_LABEL_KEY) == TEST_NAMESPACE_LABEL_VALUE
+
+
+def teardown_test_namespace(
+    core_api: kubernetes.client.CoreV1Api,
+    custom_api: kubernetes.client.CustomObjectsApi,
+    namespace: str,
+    config: TeardownConfig | None = None,
+) -> TeardownReport:
+    """Delete test resources in a deterministic order and assert no residue."""
+    cfg = config or TeardownConfig()
+    started = time.monotonic()
+    deleted_resources: dict[str, int] = {}
+    remediated_finalizers = 0
+    debug_bundle_path: str | None = None
+
+    try:
+        namespace_obj = _read_namespace(core_api, namespace)
+        if namespace_obj is None:
+            return TeardownReport(
+                namespace=namespace,
+                deleted_resources={},
+                remediated_finalizers=0,
+                duration_seconds=round(time.monotonic() - started, 3),
+            )
+
+        labels = dict(namespace_obj.metadata.labels or {})
+        if not is_test_namespace(namespace, labels):
+            raise ValueError(
+                f"Refusing teardown for non-test namespace {namespace!r}. "
+                f"Required: prefix {TEST_NAMESPACE_PREFIX!r} and label "
+                f"{TEST_NAMESPACE_LABEL_KEY}={TEST_NAMESPACE_LABEL_VALUE!r}."
+            )
+
+        resources = [
+            ("sshmachines", SSH_API_GROUP, SSH_API_VERSION),
+            ("sshclusters", SSH_API_GROUP, SSH_API_VERSION),
+            ("machines", CAPI_API_GROUP, CAPI_API_VERSION),
+            ("kubeadmconfigs", BOOTSTRAP_API_GROUP, BOOTSTRAP_API_VERSION),
+        ]
+
+        for plural, group, version in resources:
+            deleted_resources[plural] = _delete_custom_objects(custom_api, namespace, group, version, plural)
+
+        deleted_resources["secrets"] = _delete_test_secrets(core_api, namespace)
+
+        for plural, group, version in resources:
+            if not _wait_for_absence(
+                custom_api,
+                namespace=namespace,
+                group=group,
+                version=version,
+                plural=plural,
+                timeout_seconds=cfg.soft_timeout_seconds,
+                poll_interval_seconds=cfg.poll_interval_seconds,
+            ):
+                remediated_finalizers += _clear_stuck_finalizers(
+                    custom_api,
+                    namespace=namespace,
+                    group=group,
+                    version=version,
+                    plural=plural,
+                )
+                _wait_for_absence(
+                    custom_api,
+                    namespace=namespace,
+                    group=group,
+                    version=version,
+                    plural=plural,
+                    timeout_seconds=cfg.soft_timeout_seconds,
+                    poll_interval_seconds=cfg.poll_interval_seconds,
+                )
+
+        _delete_namespace(core_api, namespace)
+        _wait_for_namespace_absence(
+            core_api,
+            namespace=namespace,
+            timeout_seconds=cfg.hard_timeout_seconds,
+            poll_interval_seconds=cfg.poll_interval_seconds,
+        )
+
+        residue = collect_namespace_residue(core_api, custom_api, namespace)
+        if any(residue.values()):
+            raise AssertionError(f"Teardown residue detected for namespace {namespace}: {residue}")
+
+    except Exception:
+        if cfg.artifact_dir:
+            bundle = collect_teardown_debug_bundle(
+                core_api=core_api,
+                custom_api=custom_api,
+                namespace=namespace,
+                artifact_dir=cfg.artifact_dir,
+            )
+            debug_bundle_path = str(bundle)
+        raise
+
+    duration = round(time.monotonic() - started, 3)
+    return TeardownReport(
+        namespace=namespace,
+        deleted_resources=deleted_resources,
+        remediated_finalizers=remediated_finalizers,
+        duration_seconds=duration,
+        debug_bundle_path=debug_bundle_path,
+    )
+
+
+def collect_namespace_residue(
+    core_api: kubernetes.client.CoreV1Api,
+    custom_api: kubernetes.client.CustomObjectsApi,
+    namespace: str,
+) -> dict[str, list[str]]:
+    """Collect potentially leaked resources for a test namespace."""
+    residue: dict[str, list[str]] = {
+        "namespace": [],
+        "sshmachines": [],
+        "sshclusters": [],
+        "machines": [],
+        "kubeadmconfigs": [],
+        "secrets": [],
+    }
+
+    namespace_obj = _read_namespace(core_api, namespace)
+    if namespace_obj is not None:
+        residue["namespace"].append(namespace)
+
+    resources = [
+        ("sshmachines", SSH_API_GROUP, SSH_API_VERSION),
+        ("sshclusters", SSH_API_GROUP, SSH_API_VERSION),
+        ("machines", CAPI_API_GROUP, CAPI_API_VERSION),
+        ("kubeadmconfigs", BOOTSTRAP_API_GROUP, BOOTSTRAP_API_VERSION),
+    ]
+    for plural, group, version in resources:
+        items = _list_custom_objects(custom_api, namespace, group, version, plural)
+        residue[plural].extend(item["metadata"]["name"] for item in items)
+
+    for secret in _list_secrets(core_api, namespace):
+        if _is_test_secret(secret.metadata.name):
+            residue["secrets"].append(secret.metadata.name)
+
+    return residue
+
+
+def collect_teardown_debug_bundle(
+    core_api: kubernetes.client.CoreV1Api,
+    custom_api: kubernetes.client.CustomObjectsApi,
+    namespace: str,
+    artifact_dir: Path,
+) -> Path:
+    """Write teardown diagnostics for failed cleanup to disk."""
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    bundle_dir = artifact_dir / f"{namespace}-{int(time.time())}"
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+
+    residue = collect_namespace_residue(core_api, custom_api, namespace)
+    (bundle_dir / "residue.json").write_text(json.dumps(residue, indent=2, sort_keys=True), encoding="utf-8")
+
+    namespace_obj = _read_namespace(core_api, namespace)
+    namespace_payload: dict[str, Any] = {}
+    if namespace_obj is not None:
+        namespace_payload = {
+            "name": namespace_obj.metadata.name,
+            "labels": dict(namespace_obj.metadata.labels or {}),
+            "finalizers": list(namespace_obj.metadata.finalizers or []),
+            "deletionTimestamp": str(namespace_obj.metadata.deletion_timestamp or ""),
+            "phase": str(namespace_obj.status.phase or ""),
+        }
+    (bundle_dir / "namespace.json").write_text(
+        json.dumps(namespace_payload, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    resources = [
+        ("sshmachines", SSH_API_GROUP, SSH_API_VERSION),
+        ("sshclusters", SSH_API_GROUP, SSH_API_VERSION),
+        ("machines", CAPI_API_GROUP, CAPI_API_VERSION),
+        ("kubeadmconfigs", BOOTSTRAP_API_GROUP, BOOTSTRAP_API_VERSION),
+    ]
+    for plural, group, version in resources:
+        items = _list_custom_objects(custom_api, namespace, group, version, plural)
+        (bundle_dir / f"{plural}.json").write_text(
+            json.dumps(items, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+
+    events_payload: list[dict[str, Any]] = []
+    try:
+        events = core_api.list_namespaced_event(namespace=namespace).items
+    except kubernetes.client.ApiException as exc:
+        if exc.status != 404:
+            raise
+    else:
+        for event in events:
+            events_payload.append(
+                {
+                    "type": event.type,
+                    "reason": event.reason,
+                    "message": event.message,
+                    "count": event.count,
+                    "lastTimestamp": str(event.last_timestamp or ""),
+                    "involvedObject": {
+                        "kind": event.involved_object.kind,
+                        "name": event.involved_object.name,
+                    },
+                }
+            )
+    (bundle_dir / "events.json").write_text(
+        json.dumps(events_payload, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return bundle_dir
+
+
+def _read_namespace(core_api: kubernetes.client.CoreV1Api, namespace: str):
+    try:
+        return core_api.read_namespace(namespace)
+    except kubernetes.client.ApiException as exc:
+        if exc.status == 404:
+            return None
+        raise
+
+
+def _delete_namespace(core_api: kubernetes.client.CoreV1Api, namespace: str) -> None:
+    try:
+        core_api.delete_namespace(
+            name=namespace,
+            body=kubernetes.client.V1DeleteOptions(propagation_policy="Background"),
+        )
+    except kubernetes.client.ApiException as exc:
+        if exc.status != 404:
+            raise
+
+
+def _wait_for_namespace_absence(
+    core_api: kubernetes.client.CoreV1Api,
+    namespace: str,
+    timeout_seconds: float,
+    poll_interval_seconds: float,
+) -> bool:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if _read_namespace(core_api, namespace) is None:
+            return True
+        time.sleep(poll_interval_seconds)
+    return False
+
+
+def _list_custom_objects(
+    custom_api: kubernetes.client.CustomObjectsApi,
+    namespace: str,
+    group: str,
+    version: str,
+    plural: str,
+) -> list[dict[str, Any]]:
+    try:
+        response = custom_api.list_namespaced_custom_object(
+            group=group,
+            version=version,
+            namespace=namespace,
+            plural=plural,
+        )
+    except kubernetes.client.ApiException as exc:
+        if exc.status == 404:
+            return []
+        raise
+    return list(response.get("items", []))
+
+
+def _delete_custom_objects(
+    custom_api: kubernetes.client.CustomObjectsApi,
+    namespace: str,
+    group: str,
+    version: str,
+    plural: str,
+) -> int:
+    deleted = 0
+    for item in _list_custom_objects(custom_api, namespace, group, version, plural):
+        name = item["metadata"]["name"]
+        try:
+            custom_api.delete_namespaced_custom_object(
+                group=group,
+                version=version,
+                namespace=namespace,
+                plural=plural,
+                name=name,
+                body=kubernetes.client.V1DeleteOptions(propagation_policy="Background"),
+            )
+        except kubernetes.client.ApiException as exc:
+            if exc.status != 404:
+                raise
+        else:
+            deleted += 1
+    return deleted
+
+
+def _wait_for_absence(
+    custom_api: kubernetes.client.CustomObjectsApi,
+    namespace: str,
+    group: str,
+    version: str,
+    plural: str,
+    timeout_seconds: float,
+    poll_interval_seconds: float,
+) -> bool:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if not _list_custom_objects(custom_api, namespace, group, version, plural):
+            return True
+        time.sleep(poll_interval_seconds)
+    return False
+
+
+def _clear_stuck_finalizers(
+    custom_api: kubernetes.client.CustomObjectsApi,
+    namespace: str,
+    group: str,
+    version: str,
+    plural: str,
+) -> int:
+    patched = 0
+    for item in _list_custom_objects(custom_api, namespace, group, version, plural):
+        metadata = item.get("metadata", {})
+        name = metadata.get("name")
+        if not name:
+            continue
+        finalizers = list(metadata.get("finalizers") or [])
+        deletion_ts = metadata.get("deletionTimestamp")
+        if not finalizers or not deletion_ts:
+            continue
+        custom_api.patch_namespaced_custom_object(
+            group=group,
+            version=version,
+            namespace=namespace,
+            plural=plural,
+            name=name,
+            body={
+                "metadata": {
+                    "finalizers": [],
+                    "annotations": {
+                        "capi-provider-ssh.test/finalizer-remediated-at": str(int(time.time())),
+                    },
+                }
+            },
+        )
+        patched += 1
+    return patched
+
+
+def _list_secrets(core_api: kubernetes.client.CoreV1Api, namespace: str):
+    try:
+        return core_api.list_namespaced_secret(namespace=namespace).items
+    except kubernetes.client.ApiException as exc:
+        if exc.status == 404:
+            return []
+        raise
+
+
+def _is_test_secret(name: str | None) -> bool:
+    if not name:
+        return False
+    return name.startswith("test-")
+
+
+def _delete_test_secrets(core_api: kubernetes.client.CoreV1Api, namespace: str) -> int:
+    deleted = 0
+    for secret in _list_secrets(core_api, namespace):
+        name = secret.metadata.name
+        if not _is_test_secret(name):
+            continue
+        try:
+            core_api.delete_namespaced_secret(name=name, namespace=namespace)
+        except kubernetes.client.ApiException as exc:
+            if exc.status != 404:
+                raise
+        else:
+            deleted += 1
+    return deleted

--- a/python/tests/integration/conftest.py
+++ b/python/tests/integration/conftest.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 import base64
 import os
 import uuid
+from pathlib import Path
 
 import kubernetes
 import pytest
 
+from tests.integration.cleanup import TeardownConfig, teardown_test_namespace
 from tests.integration.helpers import API_GROUP, API_VERSION
 
 
@@ -79,7 +81,7 @@ def _require_crds(k8s_client):
 
 
 @pytest.fixture
-def test_namespace(core_api):
+def test_namespace(core_api, custom_api):
     """Create an ephemeral namespace for test isolation, delete on teardown."""
     ns_name = f"test-capi-ssh-{uuid.uuid4().hex[:8]}"
     ns_body = kubernetes.client.V1Namespace(
@@ -90,8 +92,19 @@ def test_namespace(core_api):
     )
     core_api.create_namespace(body=ns_body)
     yield ns_name
-    # Cascading delete removes all resources in the namespace
-    core_api.delete_namespace(name=ns_name, body=kubernetes.client.V1DeleteOptions(propagation_policy="Background"))
+
+    artifact_dir_env = os.environ.get("TEARDOWN_ARTIFACT_DIR")
+    artifact_dir = Path(artifact_dir_env) if artifact_dir_env else None
+    cfg = TeardownConfig(artifact_dir=artifact_dir)
+    try:
+        teardown_test_namespace(
+            core_api=core_api,
+            custom_api=custom_api,
+            namespace=ns_name,
+            config=cfg,
+        )
+    except Exception as exc:
+        raise RuntimeError(f"integration teardown failed for namespace {ns_name}: {exc}") from exc
 
 
 @pytest.fixture

--- a/python/tests/integration/test_teardown_cleanup_integration.py
+++ b/python/tests/integration/test_teardown_cleanup_integration.py
@@ -1,0 +1,21 @@
+"""Integration coverage for deterministic test namespace teardown."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.integration.cleanup import teardown_test_namespace
+
+pytestmark = [pytest.mark.integration, pytest.mark.timeout(60)]
+
+
+def test_teardown_is_idempotent(core_api, custom_api, test_namespace):
+    """Calling teardown repeatedly should be safe and non-failing."""
+    teardown_test_namespace(core_api=core_api, custom_api=custom_api, namespace=test_namespace)
+    teardown_test_namespace(core_api=core_api, custom_api=custom_api, namespace=test_namespace)
+
+
+def test_teardown_refuses_non_test_namespace(core_api, custom_api):
+    """Guardrail: never operate on non-test namespaces."""
+    with pytest.raises(ValueError, match="Refusing teardown for non-test namespace"):
+        teardown_test_namespace(core_api=core_api, custom_api=custom_api, namespace="default")

--- a/python/tests/test_teardown_cleanup.py
+++ b/python/tests/test_teardown_cleanup.py
@@ -1,0 +1,152 @@
+"""Unit tests for integration teardown contract helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import kubernetes
+import pytest
+
+from tests.integration.cleanup import (
+    TeardownConfig,
+    _clear_stuck_finalizers,
+    collect_namespace_residue,
+    is_test_namespace,
+    teardown_test_namespace,
+)
+
+
+def _api_error(status: int) -> kubernetes.client.ApiException:
+    return kubernetes.client.ApiException(status=status, reason=f"status-{status}")
+
+
+def _namespace(name: str, labels: dict[str, str] | None):
+    return SimpleNamespace(
+        metadata=SimpleNamespace(
+            name=name,
+            labels=labels,
+            finalizers=[],
+            deletion_timestamp=None,
+        ),
+        status=SimpleNamespace(phase="Active"),
+    )
+
+
+def test_is_test_namespace_requires_prefix_and_label() -> None:
+    assert is_test_namespace("test-capi-ssh-abc123", {"capi-provider-ssh-test": "true"}) is True
+    assert is_test_namespace("default", {"capi-provider-ssh-test": "true"}) is False
+    assert is_test_namespace("test-capi-ssh-abc123", {"capi-provider-ssh-test": "false"}) is False
+    assert is_test_namespace("test-capi-ssh-abc123", None) is False
+
+
+def test_teardown_rejects_non_test_namespace() -> None:
+    core_api = MagicMock()
+    custom_api = MagicMock()
+    core_api.read_namespace.return_value = _namespace("default", {"capi-provider-ssh-test": "true"})
+
+    with pytest.raises(ValueError, match="Refusing teardown for non-test namespace"):
+        teardown_test_namespace(core_api=core_api, custom_api=custom_api, namespace="default")
+
+
+def test_teardown_is_noop_when_namespace_already_deleted() -> None:
+    core_api = MagicMock()
+    custom_api = MagicMock()
+    core_api.read_namespace.side_effect = _api_error(404)
+
+    report = teardown_test_namespace(core_api=core_api, custom_api=custom_api, namespace="test-capi-ssh-deadbeef")
+    assert report.namespace == "test-capi-ssh-deadbeef"
+    assert report.deleted_resources == {}
+    assert report.remediated_finalizers == 0
+
+
+def test_clear_stuck_finalizers_patches_only_deleting_objects() -> None:
+    custom_api = MagicMock()
+    custom_api.list_namespaced_custom_object.return_value = {
+        "items": [
+            {
+                "metadata": {
+                    "name": "stuck",
+                    "deletionTimestamp": "2026-02-23T23:00:00Z",
+                    "finalizers": ["machine.cluster.x-k8s.io"],
+                }
+            },
+            {
+                "metadata": {
+                    "name": "healthy",
+                    "finalizers": [],
+                }
+            },
+        ]
+    }
+
+    patched = _clear_stuck_finalizers(
+        custom_api=custom_api,
+        namespace="test-capi-ssh-abc123",
+        group="cluster.x-k8s.io",
+        version="v1beta1",
+        plural="machines",
+    )
+
+    assert patched == 1
+    custom_api.patch_namespaced_custom_object.assert_called_once()
+    patch_body = custom_api.patch_namespaced_custom_object.call_args.kwargs["body"]
+    assert patch_body["metadata"]["finalizers"] == []
+
+
+def test_collect_namespace_residue_filters_test_secrets() -> None:
+    core_api = MagicMock()
+    custom_api = MagicMock()
+    core_api.read_namespace.return_value = _namespace("test-capi-ssh-abc123", {"capi-provider-ssh-test": "true"})
+    core_api.list_namespaced_secret.return_value = SimpleNamespace(
+        items=[
+            SimpleNamespace(metadata=SimpleNamespace(name="test-bootstrap-data")),
+            SimpleNamespace(metadata=SimpleNamespace(name="business-secret")),
+        ]
+    )
+    custom_api.list_namespaced_custom_object.return_value = {"items": []}
+
+    residue = collect_namespace_residue(
+        core_api=core_api,
+        custom_api=custom_api,
+        namespace="test-capi-ssh-abc123",
+    )
+
+    assert residue["namespace"] == ["test-capi-ssh-abc123"]
+    assert residue["secrets"] == ["test-bootstrap-data"]
+
+
+def test_teardown_collects_debug_bundle_on_failure(tmp_path) -> None:
+    core_api = MagicMock()
+    custom_api = MagicMock()
+    core_api.read_namespace.return_value = _namespace("test-capi-ssh-abc123", {"capi-provider-ssh-test": "true"})
+    core_api.list_namespaced_secret.return_value = SimpleNamespace(items=[])
+
+    custom_api.list_namespaced_custom_object.side_effect = [
+        {"items": [{"metadata": {"name": "obj1"}}]},  # sshmachines list (delete pass)
+        {"items": []},  # sshclusters list
+        {"items": []},  # machines list
+        {"items": []},  # kubeadmconfigs list
+        {"items": []},  # residue sshmachines
+        {"items": []},  # residue sshclusters
+        {"items": []},  # residue machines
+        {"items": []},  # residue kubeadmconfigs
+        {"items": []},  # bundle sshmachines
+        {"items": []},  # bundle sshclusters
+        {"items": []},  # bundle machines
+        {"items": []},  # bundle kubeadmconfigs
+    ]
+    custom_api.delete_namespaced_custom_object.side_effect = RuntimeError("delete failed")
+
+    with pytest.raises(RuntimeError, match="delete failed"):
+        teardown_test_namespace(
+            core_api=core_api,
+            custom_api=custom_api,
+            namespace="test-capi-ssh-abc123",
+            config=TeardownConfig(artifact_dir=tmp_path),
+        )
+
+    bundles = list(tmp_path.glob("test-capi-ssh-abc123-*"))
+    assert bundles, "expected teardown debug bundle directory to be created"
+    residue_files = list(bundles[0].glob("residue.json"))
+    assert residue_files, "expected residue.json in teardown debug bundle"


### PR DESCRIPTION
## Summary
This PR implements the teardown hardening requested in issue #123 point-by-point:

1. Add deterministic integration teardown engine (`python/tests/integration/cleanup.py`)
2. Enforce namespace safety guardrails (prefix + label checks)
3. Delete resources in explicit order and assert no residue
4. Add bounded stuck-finalizer remediation for test resources only
5. Emit debug evidence bundle on teardown failures
6. Wire teardown engine into integration fixture teardown (`python/tests/integration/conftest.py`)
7. Add unit tests for teardown behavior (`python/tests/test_teardown_cleanup.py`)
8. Add integration coverage for idempotency and guardrails (`python/tests/integration/test_teardown_cleanup_integration.py`)
9. Upload teardown debug artifacts in CI (`.github/workflows/ci-python.yml`)
10. Update operational docs (`docs/live-rollout-validation.md`, `docs/faq.md`)

## Validation
- `uv run ruff check tests/integration/cleanup.py tests/integration/conftest.py tests/test_teardown_cleanup.py tests/integration/test_teardown_cleanup_integration.py`
- `uv run pytest -q tests/test_teardown_cleanup.py`
- `uv run pytest -q tests/integration/test_teardown_cleanup_integration.py` (skipped by default marker policy)
- `uv run pytest -q`

Closes #123
