### PR TITLE
fix: prevent SSHMachine bootstrap re-run after provisioned

### DIFF
--- a/python/capi_provider_ssh/controllers/sshmachine.py
+++ b/python/capi_provider_ssh/controllers/sshmachine.py
@@ -567,13 +567,10 @@ def _set_reboot_status(patch, requested_at: str, success: bool, message: str) ->
 
 
 def _is_already_provisioned(status: dict, expected_provider_id: str) -> bool:
-    """Check if machine is already provisioned with matching providerID."""
+    """Check whether bootstrap already completed for this SSHMachine."""
+    _ = expected_provider_id
     init = status.get("initialization", {})
-    if not init.get("provisioned"):
-        return False
-    # Check conditions for Ready=True
-    conditions = status.get("conditions", [])
-    return any(c.get("type") == "Ready" and c.get("status") == "True" for c in conditions)
+    return bool(init.get("provisioned"))
 
 
 def _machine_consumer_ref(name: str, namespace: str) -> dict:

--- a/python/tests/test_sshmachine.py
+++ b/python/tests/test_sshmachine.py
@@ -50,7 +50,14 @@ class TestIsAlreadyProvisioned:
             "initialization": {"provisioned": True},
             "conditions": [{"type": "Ready", "status": "False"}],
         }
-        assert _is_already_provisioned(status, "ssh://10.0.0.1") is False
+        assert _is_already_provisioned(status, "ssh://10.0.0.1") is True
+
+    def test_provisioned_without_ready_condition(self):
+        status = {
+            "initialization": {"provisioned": True},
+            "conditions": [],
+        }
+        assert _is_already_provisioned(status, "ssh://10.0.0.1") is True
 
 
 class TestSSHMachineReconcile:
@@ -98,6 +105,28 @@ class TestSSHMachineReconcile:
             patch=patch_obj,
         )
         # Should not modify status (idempotent)
+        assert "initialization" not in patch_obj.get("status", {})
+
+    @pytest.mark.asyncio
+    async def test_already_provisioned_skips_when_ready_false(self, sshmachine_spec, sshmachine_meta_with_owner):
+        status = {
+            "initialization": {"provisioned": True},
+            "conditions": [{"type": "Ready", "status": "False"}],
+        }
+        with patch(
+            "capi_provider_ssh.controllers.sshmachine._read_bootstrap_data",
+            new_callable=AsyncMock,
+        ) as read_bootstrap:
+            patch_obj = kopf.Patch({})
+            await sshmachine_reconcile(
+                spec=sshmachine_spec,
+                status=status,
+                name="m1",
+                namespace="default",
+                meta=sshmachine_meta_with_owner,
+                patch=patch_obj,
+            )
+        read_bootstrap.assert_not_called()
         assert "initialization" not in patch_obj.get("status", {})
 
     @pytest.mark.asyncio
@@ -325,6 +354,27 @@ runcmd:
         status = {
             "initialization": {"provisioned": True},
             "conditions": [{"type": "Ready", "status": "True"}],
+        }
+        with patch(
+            "capi_provider_ssh.controllers.sshmachine._read_bootstrap_data",
+            new_callable=AsyncMock,
+        ) as read_bootstrap:
+            patch_obj = kopf.Patch({})
+            await sshmachine_reconcile_timer(
+                spec=sshmachine_spec,
+                status=status,
+                name="m1",
+                namespace="default",
+                meta=sshmachine_meta_with_owner,
+                patch=patch_obj,
+            )
+        read_bootstrap.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_timer_skips_provisioned_machine_when_ready_false(self, sshmachine_spec, sshmachine_meta_with_owner):
+        status = {
+            "initialization": {"provisioned": True},
+            "conditions": [{"type": "Ready", "status": "False"}],
         }
         with patch(
             "capi_provider_ssh.controllers.sshmachine._read_bootstrap_data",


### PR DESCRIPTION
## Summary
- make status.initialization.provisioned=true the hard gate for idempotency
- stop relying on Ready=True to decide whether bootstrap may run again
- add regression tests for provisioned=true with Ready=False and timer reconcile path

## Why
A provisioned control-plane machine could be bootstrapped twice if Ready flipped, causing destructive side effects (kubeadm reset -f in second run).

Closes #127

## Validation
- UV_CACHE_DIR=/tmp/uv-cache uv run ruff check capi_provider_ssh/controllers/sshmachine.py tests/test_sshmachine.py
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_sshmachine.py tests/test_ssh.py tests/test_sshhost.py -q
