### PR TITLE
docs: add ITSM change record and ISO 20000 continuity guidance

### DIFF
--- a/.github/docs/README.md
+++ b/.github/docs/README.md
@@ -1,0 +1,19 @@
+# Governance Docs
+
+This directory contains governance and process documentation for this
+repository.
+
+## Contents
+
+- `centralized-workflows.md`: Standardized GitHub Actions workflows and release
+  automation conventions.
+- `itsm-change-record-standard.md`: Enterprise-grade change record model for
+  provider repositories, with ISO/ITIL source mapping.
+- `iso20000-service-continuity-research.md`: Research summary on publicly
+  available ISO/IEC 20000 service continuity planning artifacts.
+- `templates/itsm-change-record-template.md`: Internal change record template
+  for standard, normal, and emergency changes.
+- `templates/iso20000-service-continuity-plan-template.md`: Internal service
+  continuity plan template aligned to ISO/IEC 20000 concepts.
+- `checklists/iso20000-service-continuity-checklist.md`: Review checklist for
+  continuity-plan completeness and test evidence.

--- a/.github/docs/checklists/iso20000-service-continuity-checklist.md
+++ b/.github/docs/checklists/iso20000-service-continuity-checklist.md
@@ -1,0 +1,54 @@
+# Service Continuity Plan Checklist (ISO/IEC 20000-aligned, Internal)
+
+Use this checklist when reviewing a continuity plan before approval.
+
+## 1. Governance and Ownership
+
+- [ ] Plan owner is defined and accountable.
+- [ ] Version, approval date, and next review date are present.
+- [ ] Escalation authority is explicit.
+
+## 2. Scope and Dependency Clarity
+
+- [ ] In-scope services are explicitly listed.
+- [ ] Critical upstream/downstream dependencies are mapped.
+- [ ] Third-party responsibilities are defined.
+
+## 3. Continuity Targets
+
+- [ ] RTO and RPO are documented for critical functions.
+- [ ] Minimum acceptable service level during disruption is defined.
+- [ ] Objectives are approved by service owner.
+
+## 4. Risk and Business Impact
+
+- [ ] High-impact disruption scenarios are documented.
+- [ ] Business impact rationale is current.
+- [ ] Assumptions and constraints are stated.
+
+## 5. Recovery Strategy Quality
+
+- [ ] Activation criteria are testable and unambiguous.
+- [ ] Step-by-step response and recovery runbook exists.
+- [ ] Required credentials/access procedures are documented.
+- [ ] Data backup/restore strategy is included.
+
+## 6. Communications
+
+- [ ] Stakeholder communication matrix exists.
+- [ ] Internal and external contact channels are current.
+- [ ] Status update cadence is defined for incidents.
+
+## 7. Testing and Evidence
+
+- [ ] Exercise schedule is defined (tabletop/simulation/restore drills).
+- [ ] Last exercise date and result are recorded.
+- [ ] Corrective actions from tests are tracked to closure.
+- [ ] Evidence artifacts are linked and retrievable.
+
+## 8. Continuous Improvement
+
+- [ ] Review cadence is defined and met.
+- [ ] Plan updated after significant architectural changes.
+- [ ] Plan updated after incidents and postmortems.
+- [ ] Open risks and accepted exceptions are documented.

--- a/.github/docs/iso20000-service-continuity-research.md
+++ b/.github/docs/iso20000-service-continuity-research.md
@@ -1,0 +1,62 @@
+# ISO/IEC 20000 Service Continuity Plan Research
+
+## Research Question
+
+Does `committee.iso.org` provide a public ISO/IEC 20000 service continuity plan
+document/template/checklist that can be directly adopted?
+
+## Finding (2026-02-24)
+
+No standalone public "Service Continuity Plan template" was found on the
+ISO/SC40 committee resources pages.
+
+Publicly available "similar" artifacts do exist:
+
+1. Service Management Plan (SMP) template and guidance (free PDF) that
+   explicitly references continuity planning as required supporting material.
+2. ISO/IEC TS 20000-5 guidance publication page (implementation guidance,
+   full text paid).
+3. TS 20000-5 infographic (free) that provides phased implementation and common
+   challenge patterns.
+4. ISO/IEC TS 20000-11 page on relationship between ISO/IEC 20000-1 and ITIL.
+
+## Interpretation for this Repository
+
+Because no public dedicated continuity template was located on the committee
+site, this repo provides an internal template/checklist aligned to ISO/IEC 20000
+concepts, with clear labeling that it is an internal implementation aid and not
+official ISO normative text.
+
+Provided outputs:
+
+- `templates/iso20000-service-continuity-plan-template.md`
+- `checklists/iso20000-service-continuity-checklist.md`
+
+## How We Came to This
+
+Method used:
+
+1. Checked ISO/SC40 service management resource page for downloadable template
+   assets and guidance.
+2. Searched committee publication pages for continuity-plan-specific templates.
+3. Collected closest official alternatives (SMP template, TS 20000-5 assets,
+   TS 20000-11 relationship note).
+4. Produced internal continuity planning artifacts that follow enterprise
+   governance expectations while remaining implementation-friendly.
+
+## References (Retrieved 2026-02-24)
+
+1. ISO/SC40 resources for ISO/IEC 20000-1:
+   https://committee.iso.org/sites/jtc1sc40/home/resources/content-left-area/service-management-resources/iso-iec-20000-1-2018.html
+2. Service Management Plan template (SC40 PDF):
+   https://committee.iso.org/files/live/sites/jtc1sc40/files/SM%20Plan%20template%20SC40-2%20202501
+3. ISO/IEC TS 20000-5:2022 page:
+   https://www.iso.org/standard/81164.html
+4. TS 20000-5 infographic (SC40 PDF):
+   https://committee.iso.org/files/live/sites/jtc1sc40/files/ISOIEC%20TS%2020000-5.pdf
+5. Guide to use/publication history for ISO/IEC 20000 standards:
+   https://committee.iso.org/sites/jtc1sc40/home/wg2/publications/publicationhistory2/guide-to-use-and-publication-his.html
+6. ISO/IEC TS 20000-11 relationship with ITIL:
+   https://committee.iso.org/sites/jtc1sc40/home/wg2/publications/iso-iec-ts-20000-11.html
+7. ISO/IEC 20000-1:2018 standard page:
+   https://www.iso.org/standard/70636.html

--- a/.github/docs/itsm-change-record-standard.md
+++ b/.github/docs/itsm-change-record-standard.md
@@ -1,0 +1,114 @@
+# ITSM Change Record Standard for Provider Repositories
+
+## Purpose
+
+Define a practical, auditable change record model for this repository that is
+compatible with enterprise change governance while remaining lightweight enough
+for startup teams.
+
+## Scope
+
+Applies to provider changes promoted through `develop -> main`, including code,
+release metadata, and published container artifacts.
+
+## What is Standardized vs Organization-Specific
+
+| Area | Standardized by ISO/ITIL | Organization-specific |
+| --- | --- | --- |
+| Change control process existence | Yes | No |
+| Required evidence and traceability | Yes (process outcome required) | No |
+| Exact ticket form fields and workflow states | No | Yes |
+| CAB/approval model and risk thresholds | No | Yes |
+| Tooling (ServiceNow/Jira/GitHub-only) | No | Yes |
+
+## Minimum Change Record Schema
+
+Use these fields for every normal change:
+
+1. `change_id`: Internal ITSM ID or GitHub-based surrogate ID.
+2. `title`: One-line change intent.
+3. `type`: `standard`, `normal`, or `emergency`.
+4. `service_scope`: Systems and environments affected.
+5. `risk_and_impact`: Impact, blast radius, rollback complexity.
+6. `implementation_plan`: Concrete execution steps.
+7. `validation_plan`: Tests and acceptance checks.
+8. `backout_plan`: Rollback steps and trigger conditions.
+9. `approvals`: Required approvers and approval timestamps.
+10. `execution_window`: Planned start/end UTC timestamps.
+11. `evidence_links`: Issue, PRs, workflow runs, release, image digest.
+12. `post_implementation_review`: Outcome, incidents, follow-ups.
+
+## Mapping to GitHub Artifacts
+
+| Change record field | GitHub evidence |
+| --- | --- |
+| Problem statement | GitHub Issue |
+| Proposed remediation | Fix PR into `develop` |
+| Promotion approval | Release PR `develop -> main` |
+| Test evidence | GitHub Actions checks and run logs |
+| Released version | GitHub Release tag |
+| Deployable artifact | GHCR image tag + digest |
+| Closure evidence | Closed issue + merged PR links |
+
+Example sequence in this repo:
+
+- Issue: `#127`
+- Fix PR: `#128` (`fix/issue-127-no-bootstrap-rerun -> develop`)
+- Release PR: `#130` (`develop -> main`)
+- Release: `v0.3.5`
+- Container: `ghcr.io/alpininsight/capi-provider-ssh-python:v0.3.5`
+
+## Automation Boundary
+
+Automated:
+
+- CI checks
+- Release/tag publication
+- Container build and publish
+- Immutable artifact metadata (tags/digests/run logs)
+
+Manual/controlled:
+
+- Risk classification
+- Approval decisions
+- Merge decisions
+- Final operational sign-off
+
+## Standard Operating Flow for this Repository
+
+1. Open an issue with reproducible impact and acceptance criteria.
+2. Implement on `fix/*` or `feat/*` branch and open PR to `develop`.
+3. Require successful checks and required approvals.
+4. Merge to `develop`.
+5. Open release PR from `develop` to `main`.
+6. Merge release PR after checks pass.
+7. Confirm release tag and container digest.
+8. Close issue with final evidence links.
+
+## How This Document Was Derived
+
+Method used on 2026-02-24:
+
+1. Reviewed official ISO pages for ISO/IEC 20000 normative and guidance
+   publications.
+2. Reviewed ISO/SC40 public resources for free templates/guidance.
+3. Reviewed official PeopleCert ITIL pages for Change Enablement practice
+   framing and publication access model.
+4. Mapped those governance requirements to this repo's existing GitHub flow.
+
+## References (Retrieved 2026-02-24)
+
+1. ISO/IEC 20000-1:2018 standard page:
+   https://www.iso.org/standard/70636.html
+2. ISO/IEC TS 20000-5:2022 guidance page:
+   https://www.iso.org/standard/81164.html
+3. ISO/SC40 service management resources (includes free template assets):
+   https://committee.iso.org/sites/jtc1sc40/home/resources/content-left-area/service-management-resources/iso-iec-20000-1-2018.html
+4. ISO/SC40 Service Management Plan template PDF:
+   https://committee.iso.org/files/live/sites/jtc1sc40/files/SM%20Plan%20template%20SC40-2%20202501
+5. ITIL 4 Practitioner: Change Enablement (PeopleCert):
+   https://www.peoplecert.org/browse-certifications/it-governance-and-service-management/ITIL-1/itil-4-practitioner-change-enablement-3794
+6. PeopleCert library/access model for ITIL practice publications:
+   https://www.peoplecert.org/Membership/peoplecert-library
+7. ISO/IEC TS 20000-11 relationship to ITIL page:
+   https://committee.iso.org/sites/jtc1sc40/home/wg2/publications/iso-iec-ts-20000-11.html

--- a/.github/docs/templates/iso20000-service-continuity-plan-template.md
+++ b/.github/docs/templates/iso20000-service-continuity-plan-template.md
@@ -1,0 +1,96 @@
+# Service Continuity Plan Template (ISO/IEC 20000-aligned, Internal)
+
+> This template is an internal implementation aid. It is not official ISO
+> normative text.
+
+## 1. Document Control
+
+- Plan ID:
+- Service name:
+- Owner:
+- Version:
+- Approved by:
+- Approval date (UTC):
+- Next review date (UTC):
+
+## 2. Service Scope and Critical Dependencies
+
+- In-scope service(s):
+- Upstream dependencies:
+- Downstream dependencies:
+- Third-party dependencies:
+- Configuration items and owners:
+
+## 3. Continuity Objectives
+
+- Maximum tolerable outage:
+- Recovery time objective (RTO):
+- Recovery point objective (RPO):
+- Minimum acceptable service level during disruption:
+
+## 4. Business Impact and Risk Summary
+
+- Critical business processes supported:
+- Priority ranking of service functions:
+- Key risk scenarios:
+- Assumptions and constraints:
+
+## 5. Continuity Strategy
+
+- Preventive controls:
+- Detection and alerting controls:
+- Degradation/failover strategy:
+- Recovery strategy:
+- Data protection strategy:
+
+## 6. Activation Criteria and Governance
+
+- Criteria for plan activation:
+- Incident commander role:
+- Escalation path:
+- Decision authority for recovery options:
+
+## 7. Response and Recovery Procedures
+
+1. Initial triage steps
+2. Stabilization actions
+3. Recovery actions
+4. Verification of restored service
+5. Handover to normal operations
+
+## 8. Communication Plan
+
+- Internal stakeholders:
+- External stakeholders/customers:
+- Regulatory/legal contacts (if applicable):
+- Communication channels:
+- Status update cadence:
+
+## 9. Resource and Access Requirements
+
+- Required systems and credentials:
+- Break-glass procedures:
+- Backup locations and restoration tooling:
+- Dependency team contacts:
+
+## 10. Test and Exercise Plan
+
+- Test frequency:
+- Test types (tabletop, simulation, restore drill):
+- Entry/exit criteria:
+- Evidence captured per test:
+
+## 11. Maintenance and Improvement
+
+- Review frequency:
+- Change triggers requiring plan update:
+- Findings log and corrective actions:
+- Ownership for remediation closure:
+
+## 12. Evidence Register
+
+- Latest test reports:
+- Incident postmortems:
+- Backup restore evidence:
+- Approval records:
+- Linked change records:

--- a/.github/docs/templates/itsm-change-record-template.md
+++ b/.github/docs/templates/itsm-change-record-template.md
@@ -1,0 +1,63 @@
+# ITSM Change Record Template (Provider Repos)
+
+## 1. Change Identification
+
+- `change_id`:
+- `title`:
+- `type` (`standard|normal|emergency`):
+- `requested_by`:
+- `owner`:
+- `planned_window_utc`:
+
+## 2. Scope and Impact
+
+- `service_scope`:
+- `environments`:
+- `affected_components`:
+- `risk_level`:
+- `business_impact`:
+
+## 3. Implementation Plan
+
+1. Step 1:
+2. Step 2:
+3. Step 3:
+
+## 4. Validation Plan
+
+- Pre-change checks:
+- Functional tests:
+- Non-functional checks:
+- Success criteria:
+
+## 5. Backout Plan
+
+- Rollback trigger conditions:
+- Rollback steps:
+- Data/state restoration steps:
+- Max rollback window:
+
+## 6. Approvals
+
+- Service owner approval:
+- Platform/SRE approval:
+- Security approval (if required):
+- CAB approval (if required):
+
+## 7. Evidence Links
+
+- Issue:
+- Fix PR (`-> develop`):
+- Release PR (`develop -> main`):
+- CI run(s):
+- Release tag:
+- Container image tag:
+- Container digest:
+
+## 8. Post-Implementation Review
+
+- Actual start/end time:
+- Outcome (`success|partial|failed`):
+- Incidents observed:
+- Follow-up actions:
+- Ticket closure date:


### PR DESCRIPTION
## Summary
- add governance docs index under .github/docs
- add enterprise change record standard doc with source references and derivation method
- add ISO/IEC 20000 continuity research doc covering available public committee resources
- add internal templates:
  - ITSM change record template
  - ISO 20000-aligned service continuity plan template
  - service continuity review checklist

## Why
We need repository-local documentation that explains how enterprise teams process change evidence, what is standardized vs organization-specific, and how to handle ISO 20000 continuity planning when no standalone public committee template is available.

## References captured in docs
- ISO/IEC 20000-1 and TS 20000-5 pages
- ISO/SC40 service management resources and SMP template
- TS 20000-5 infographic
- ISO/IEC TS 20000-11 relation to ITIL
- official PeopleCert ITIL pages
