### PR TITLE
fix: prevent handler/timer bootstrap race on SSHMachine

### DIFF
--- a/python/capi_provider_ssh/controllers/sshmachine.py
+++ b/python/capi_provider_ssh/controllers/sshmachine.py
@@ -7,6 +7,7 @@ This is the core controller of the provider. It handles:
 - Status management (providerID, addresses, conditions)
 """
 
+import asyncio
 import base64
 import datetime
 import logging
@@ -30,6 +31,7 @@ DEFAULT_EXTERNAL_ETCD_KEY_FILE = "/etc/kubernetes/pki/etcd-external/client.key"
 SSHMACHINE_RECONCILE_INTERVAL = int(
     os.environ.get("SSHMACHINE_RECONCILE_INTERVAL", os.environ.get("RECONCILE_INTERVAL", "60")),
 )
+_RECONCILE_LOCKS: dict[str, asyncio.Lock] = {}
 
 
 def _now_iso() -> str:
@@ -573,6 +575,36 @@ def _is_already_provisioned(status: dict, expected_provider_id: str) -> bool:
     return bool(init.get("provisioned"))
 
 
+def _reconcile_lock_key(namespace: str, name: str) -> str:
+    return f"{namespace}/{name}"
+
+
+def _get_reconcile_lock(namespace: str, name: str) -> asyncio.Lock:
+    key = _reconcile_lock_key(namespace, name)
+    lock = _RECONCILE_LOCKS.get(key)
+    if lock is None:
+        lock = asyncio.Lock()
+        _RECONCILE_LOCKS[key] = lock
+    return lock
+
+
+def _read_current_sshmachine(namespace: str, name: str) -> dict | None:
+    """Read the latest SSHMachine object state from the API server."""
+    api = kubernetes.client.CustomObjectsApi()
+    try:
+        return api.get_namespaced_custom_object(
+            group=API_GROUP,
+            version=API_VERSION,
+            namespace=namespace,
+            plural="sshmachines",
+            name=name,
+        )
+    except kubernetes.client.ApiException as e:
+        if e.status == 404:
+            return None
+        raise
+
+
 def _machine_consumer_ref(name: str, namespace: str) -> dict:
     """Build consumerRef payload for an SSHMachine."""
     return {
@@ -868,9 +900,7 @@ async def _release_host(spec: dict, name: str, namespace: str) -> None:
     logger.warning("SSHMachine %s/%s failed to release SSHHost %s after retries", namespace, name, host_ref)
 
 
-@kopf.on.create(API_GROUP, API_VERSION, "sshmachines")
-@kopf.on.update(API_GROUP, API_VERSION, "sshmachines")
-async def sshmachine_reconcile(spec, status, name, namespace, meta, patch, **_kwargs):
+async def _sshmachine_reconcile_impl(spec, status, name, namespace, meta, patch, **_kwargs):
     """Reconcile SSHMachine -- bootstrap or verify via SSH."""
     logger.info("SSHMachine %s/%s reconciling", namespace, name)
 
@@ -1073,6 +1103,43 @@ async def sshmachine_reconcile(spec, status, name, namespace, meta, patch, **_kw
     patch.status["failureMessage"] = None
 
     logger.info("SSHMachine %s/%s provisioned: providerID=%s", namespace, name, provider_id)
+
+
+@kopf.on.create(API_GROUP, API_VERSION, "sshmachines")
+@kopf.on.update(API_GROUP, API_VERSION, "sshmachines")
+async def sshmachine_reconcile(spec, status, name, namespace, meta, patch, **_kwargs):
+    """Serialized SSHMachine reconcile entrypoint for create/update events."""
+    lock = _get_reconcile_lock(namespace, name)
+    waited_for_lock = lock.locked()
+    if waited_for_lock:
+        logger.info("SSHMachine %s/%s waiting for active reconcile to finish", namespace, name)
+
+    async with lock:
+        if waited_for_lock:
+            try:
+                latest = _read_current_sshmachine(namespace, name)
+            except Exception as e:
+                logger.warning(
+                    "SSHMachine %s/%s failed to refresh live state after reconcile wait: %s",
+                    namespace,
+                    name,
+                    e,
+                )
+            else:
+                if latest is not None:
+                    spec = latest.get("spec", spec)
+                    status = latest.get("status", status)
+                    meta = latest.get("metadata", meta)
+                    logger.info("SSHMachine %s/%s refreshed live state after reconcile wait", namespace, name)
+
+        await _sshmachine_reconcile_impl(
+            spec=spec,
+            status=status,
+            name=name,
+            namespace=namespace,
+            meta=meta,
+            patch=patch,
+        )
 
 
 @kopf.timer(

--- a/python/tests/test_sshmachine.py
+++ b/python/tests/test_sshmachine.py
@@ -1,5 +1,6 @@
 """Tests for SSHMachine controller."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import kopf
@@ -8,6 +9,7 @@ import pytest
 from capi_provider_ssh.controllers.sshmachine import (
     _choose_host,
     _detect_bootstrap_format,
+    _get_reconcile_lock,
     _has_machine_owner,
     _inject_external_etcd_into_bootstrap_data,
     _is_already_provisioned,
@@ -390,6 +392,105 @@ runcmd:
                 patch=patch_obj,
             )
         read_bootstrap.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_waiting_reconcile_refreshes_live_state_and_skips_bootstrap(
+        self,
+        sshmachine_spec,
+        sshmachine_meta_with_owner,
+    ):
+        name = "m-race-refresh"
+        namespace = "default"
+        lock = _get_reconcile_lock(namespace, name)
+        await lock.acquire()
+
+        latest = {
+            "spec": sshmachine_spec,
+            "status": {
+                "initialization": {"provisioned": True},
+                "conditions": [{"type": "Ready", "status": "True"}],
+            },
+            "metadata": sshmachine_meta_with_owner,
+        }
+
+        task = None
+        try:
+            with (
+                patch(
+                    "capi_provider_ssh.controllers.sshmachine._read_current_sshmachine",
+                    return_value=latest,
+                ),
+                patch(
+                    "capi_provider_ssh.controllers.sshmachine._read_bootstrap_data",
+                    new_callable=AsyncMock,
+                ) as read_bootstrap,
+            ):
+                patch_obj = kopf.Patch({})
+                task = asyncio.create_task(
+                    sshmachine_reconcile(
+                        spec=sshmachine_spec,
+                        status={},
+                        name=name,
+                        namespace=namespace,
+                        meta=sshmachine_meta_with_owner,
+                        patch=patch_obj,
+                    ),
+                )
+                await asyncio.sleep(0)
+                lock.release()
+                await task
+                read_bootstrap.assert_not_called()
+        finally:
+            if task is not None and not task.done():
+                await task
+            if lock.locked():
+                lock.release()
+
+    @pytest.mark.asyncio
+    async def test_handler_and_timer_reconcile_are_serialized(self, sshmachine_spec, sshmachine_meta_with_owner):
+        name = "m-race-serialized"
+        namespace = "default"
+        active = 0
+        max_active = 0
+
+        async def fake_impl(**_kwargs):
+            nonlocal active, max_active
+            active += 1
+            max_active = max(max_active, active)
+            await asyncio.sleep(0.05)
+            active -= 1
+
+        with (
+            patch(
+                "capi_provider_ssh.controllers.sshmachine._read_current_sshmachine",
+                return_value=None,
+            ),
+            patch(
+                "capi_provider_ssh.controllers.sshmachine._sshmachine_reconcile_impl",
+                new=AsyncMock(side_effect=fake_impl),
+            ) as reconcile_impl,
+        ):
+            await asyncio.gather(
+                sshmachine_reconcile(
+                    spec=sshmachine_spec,
+                    status={},
+                    name=name,
+                    namespace=namespace,
+                    meta=sshmachine_meta_with_owner,
+                    patch=kopf.Patch({}),
+                ),
+                sshmachine_reconcile_timer(
+                    spec=sshmachine_spec,
+                    status={},
+                    name=name,
+                    namespace=namespace,
+                    meta=sshmachine_meta_with_owner,
+                    patch=kopf.Patch({}),
+                ),
+            )
+
+        assert reconcile_impl.await_count == 2
+        assert max_active == 1
 
 
 class TestSSHMachineDryRun:


### PR DESCRIPTION
## Summary
- serialize reconcile execution per SSHMachine across handler and timer paths
- refresh live SSHMachine state after waiting on lock to avoid stale status re-entry
- add regression tests for lock serialization and stale-state refresh behavior

## Root cause
Concurrent handler and timer reconcilers could both enter bootstrap before status.provisioned was persisted, allowing a second run that executes destructive reset logic.

Closes #133

## Validation
- UV_CACHE_DIR=/tmp/uv-cache uv run ruff check capi_provider_ssh/controllers/sshmachine.py tests/test_sshmachine.py
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_sshmachine.py tests/test_ssh.py tests/test_sshhost.py -q
