### PR TITLE
fix: prevent ModuleNotFoundError in develop image startup

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -27,4 +27,4 @@ LABEL org.opencontainers.image.vendor="Alpin Insight Solutions" \
       org.opencontainers.image.source="https://github.com/alpininsight/capi-provider-ssh" \
       org.opencontainers.image.description="Cluster API infrastructure provider for SSH-reachable hosts"
 
-ENTRYPOINT ["kopf", "run", "--standalone", "--liveness=http://0.0.0.0:8080/healthz", "capi_provider_ssh/main.py"]
+ENTRYPOINT ["kopf", "run", "--standalone", "--liveness=http://0.0.0.0:8080/healthz", "-m", "capi_provider_ssh.main"]

--- a/python/tests/test_runtime_regression.py
+++ b/python/tests/test_runtime_regression.py
@@ -24,6 +24,12 @@ def test_docker_entrypoint_uses_kopf_directly() -> None:
     assert "--liveness=http://0.0.0.0:8080/healthz" in entrypoint, (
         "Regression guard: probes target /healthz on 8080, so Kopf liveness must be enabled in ENTRYPOINT."
     )
+    assert '"-m", "capi_provider_ssh.main"' in entrypoint, (
+        "Regression guard: ENTRYPOINT must run module mode to avoid brittle script-path imports."
+    )
+    assert "capi_provider_ssh/main.py" not in entrypoint, (
+        "Regression guard: do not execute package module via file path in ENTRYPOINT."
+    )
 
 
 def test_dockerfile_exports_venv_bin_on_path() -> None:


### PR DESCRIPTION
## Summary
- switch Docker ENTRYPOINT to module mode (kopf run -m capi_provider_ssh.main)
- keep direct kopf run (no uv run) and liveness endpoint unchanged
- add regression asserts to prevent fallback to file-path invocation

## Why
Counterparty reported startup failure on develop/prerelease image:
ModuleNotFoundError: No module named capi_provider_ssh

Module mode is more robust than file-path execution for runtime import resolution.

Closes #137

## Validation
- UV_CACHE_DIR=/tmp/uv-cache uv run ruff check capi_provider_ssh tests/test_runtime_regression.py
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_runtime_regression.py tests/test_sshmachine.py tests/test_ssh.py tests/test_sshhost.py -q
