### PR TITLE
fix: prevent cross-pod concurrent SSHMachine bootstrap

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -98,6 +98,29 @@ New releases are cut automatically when `develop` is merged into `main`. Check
 the [Releases page](https://github.com/alpininsight/capi-provider-ssh/releases)
 for the latest stable tag.
 
+## How does the provider prevent concurrent bootstrap across multiple controller pods?
+
+The SSHMachine controller now applies a **cross-process distributed lock** on
+each `SSHMachine` by writing a lock annotation with optimistic concurrency
+(`metadata.resourceVersion` compare-and-swap). This sits on top of the existing
+in-process `asyncio.Lock`.
+
+Behavior:
+
+1. Reconcile/delete handlers first acquire the in-process per-machine lock.
+2. Then they acquire the distributed lock annotation.
+3. If another pod already holds the lock, the handler requeues with
+   `kopf.TemporaryError` and does not execute bootstrap/cleanup.
+
+Environment controls:
+
+- `SSHMACHINE_DISTRIBUTED_LOCK_ENABLED` (default: `true`)
+- `SSHMACHINE_DISTRIBUTED_LOCK_TTL_SECONDS` (default: `7200`)
+- `SSHMACHINE_DISTRIBUTED_LOCK_RETRY_DELAY_SECONDS` (default: `5`)
+
+This protects rolling-update overlap windows where two operator instances may
+be active briefly.
+
 ## How does integration test teardown avoid leaked test namespaces?
 
 Integration tests now use a deterministic teardown contract in

--- a/python/capi_provider_ssh/controllers/sshmachine.py
+++ b/python/capi_provider_ssh/controllers/sshmachine.py
@@ -15,6 +15,9 @@ import os
 import posixpath
 import re
 import shlex
+import socket
+import time
+import uuid
 
 import kopf
 import kubernetes
@@ -31,7 +34,21 @@ DEFAULT_EXTERNAL_ETCD_KEY_FILE = "/etc/kubernetes/pki/etcd-external/client.key"
 SSHMACHINE_RECONCILE_INTERVAL = int(
     os.environ.get("SSHMACHINE_RECONCILE_INTERVAL", os.environ.get("RECONCILE_INTERVAL", "60")),
 )
+SSHMACHINE_DISTRIBUTED_LOCK_ENABLED = os.environ.get("SSHMACHINE_DISTRIBUTED_LOCK_ENABLED", "true").lower() not in {
+    "0",
+    "false",
+    "no",
+}
+SSHMACHINE_DISTRIBUTED_LOCK_TTL_SECONDS = int(os.environ.get("SSHMACHINE_DISTRIBUTED_LOCK_TTL_SECONDS", "7200"))
+SSHMACHINE_DISTRIBUTED_LOCK_RETRY_DELAY_SECONDS = int(
+    os.environ.get("SSHMACHINE_DISTRIBUTED_LOCK_RETRY_DELAY_SECONDS", "5"),
+)
+SSHMACHINE_DISTRIBUTED_LOCK_ANNOTATION = "infrastructure.cluster.x-k8s.io/reconcile-lock"
 _RECONCILE_LOCKS: dict[str, asyncio.Lock] = {}
+_RECONCILE_LOCK_HOLDER = (
+    f"{(os.environ.get('POD_NAME') or os.environ.get('HOSTNAME') or socket.gethostname()).replace('|', '_')}"
+    f":{os.getpid()}:{uuid.uuid4().hex[:8]}"
+)
 
 
 def _now_iso() -> str:
@@ -605,6 +622,188 @@ def _cleanup_reconcile_lock(namespace: str, name: str, lock: asyncio.Lock | None
     return True
 
 
+def _distributed_reconcile_lock_value(holder: str, expires_epoch: int) -> str:
+    return f"{holder}|{expires_epoch}"
+
+
+def _parse_distributed_reconcile_lock_value(value: str | None) -> tuple[str, int] | None:
+    if not value:
+        return None
+    holder, separator, raw_expires = value.rpartition("|")
+    if not separator or not holder:
+        return None
+    try:
+        expires_epoch = int(raw_expires)
+    except ValueError:
+        return None
+    return holder, expires_epoch
+
+
+def _acquire_distributed_reconcile_lock(namespace: str, name: str) -> bool:
+    """Acquire a cross-process reconcile lock via SSHMachine metadata annotation."""
+    if not SSHMACHINE_DISTRIBUTED_LOCK_ENABLED:
+        return True
+
+    api = kubernetes.client.CustomObjectsApi()
+    ttl_seconds = max(30, SSHMACHINE_DISTRIBUTED_LOCK_TTL_SECONDS)
+
+    for _ in range(5):
+        obj = api.get_namespaced_custom_object(
+            group=API_GROUP,
+            version=API_VERSION,
+            namespace=namespace,
+            plural="sshmachines",
+            name=name,
+        )
+        metadata = obj.get("metadata", {})
+        resource_version = metadata.get("resourceVersion")
+        if not resource_version:
+            logger.warning("SSHMachine %s/%s lock acquisition skipped: missing resourceVersion", namespace, name)
+            return False
+
+        annotations = metadata.get("annotations") or {}
+        lock_value = annotations.get(SSHMACHINE_DISTRIBUTED_LOCK_ANNOTATION)
+        parsed = _parse_distributed_reconcile_lock_value(lock_value)
+        now_epoch = int(time.time())
+        if parsed is not None:
+            current_holder, expires_epoch = parsed
+            if current_holder != _RECONCILE_LOCK_HOLDER and expires_epoch > now_epoch:
+                return False
+
+        new_lock_value = _distributed_reconcile_lock_value(_RECONCILE_LOCK_HOLDER, now_epoch + ttl_seconds)
+        body = {
+            "metadata": {
+                "resourceVersion": resource_version,
+                "annotations": {SSHMACHINE_DISTRIBUTED_LOCK_ANNOTATION: new_lock_value},
+            },
+        }
+        try:
+            api.patch_namespaced_custom_object(
+                group=API_GROUP,
+                version=API_VERSION,
+                namespace=namespace,
+                plural="sshmachines",
+                name=name,
+                body=body,
+            )
+            return True
+        except kubernetes.client.ApiException as e:
+            if e.status == 409:
+                continue
+            if e.status == 404:
+                return False
+            raise
+
+    return False
+
+
+def _release_distributed_reconcile_lock(namespace: str, name: str) -> bool:
+    """Release a cross-process reconcile lock when held by this controller instance."""
+    if not SSHMACHINE_DISTRIBUTED_LOCK_ENABLED:
+        return True
+
+    api = kubernetes.client.CustomObjectsApi()
+    for _ in range(5):
+        try:
+            obj = api.get_namespaced_custom_object(
+                group=API_GROUP,
+                version=API_VERSION,
+                namespace=namespace,
+                plural="sshmachines",
+                name=name,
+            )
+        except kubernetes.client.ApiException as e:
+            if e.status == 404:
+                return True
+            raise
+
+        metadata = obj.get("metadata", {})
+        resource_version = metadata.get("resourceVersion")
+        if not resource_version:
+            return False
+
+        annotations = metadata.get("annotations") or {}
+        lock_value = annotations.get(SSHMACHINE_DISTRIBUTED_LOCK_ANNOTATION)
+        parsed = _parse_distributed_reconcile_lock_value(lock_value)
+        if parsed is None:
+            return True
+
+        current_holder, _expires_epoch = parsed
+        if current_holder != _RECONCILE_LOCK_HOLDER:
+            return False
+
+        body = {
+            "metadata": {
+                "resourceVersion": resource_version,
+                "annotations": {SSHMACHINE_DISTRIBUTED_LOCK_ANNOTATION: None},
+            },
+        }
+        try:
+            api.patch_namespaced_custom_object(
+                group=API_GROUP,
+                version=API_VERSION,
+                namespace=namespace,
+                plural="sshmachines",
+                name=name,
+                body=body,
+            )
+            return True
+        except kubernetes.client.ApiException as e:
+            if e.status == 409:
+                continue
+            if e.status == 404:
+                return True
+            raise
+
+    return False
+
+
+def _acquire_distributed_lock_or_requeue(namespace: str, name: str, operation: str) -> None:
+    try:
+        acquired = _acquire_distributed_reconcile_lock(namespace, name)
+    except Exception as e:  # noqa: BLE001
+        raise kopf.TemporaryError(
+            f"distributed reconcile lock acquisition failed during {operation}: {e}",
+            delay=SSHMACHINE_DISTRIBUTED_LOCK_RETRY_DELAY_SECONDS,
+        ) from e
+
+    if acquired:
+        return
+
+    logger.info(
+        "SSHMachine %s/%s waiting for distributed reconcile lock during %s",
+        namespace,
+        name,
+        operation,
+    )
+    raise kopf.TemporaryError(
+        f"distributed reconcile lock is held by another controller during {operation}",
+        delay=SSHMACHINE_DISTRIBUTED_LOCK_RETRY_DELAY_SECONDS,
+    )
+
+
+def _release_distributed_lock_with_logging(namespace: str, name: str, operation: str) -> None:
+    try:
+        released = _release_distributed_reconcile_lock(namespace, name)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "SSHMachine %s/%s failed to release distributed reconcile lock during %s: %s",
+            namespace,
+            name,
+            operation,
+            e,
+        )
+        return
+
+    if not released:
+        logger.warning(
+            "SSHMachine %s/%s distributed reconcile lock ownership changed before release during %s",
+            namespace,
+            name,
+            operation,
+        )
+
+
 def _read_current_sshmachine(namespace: str, name: str) -> dict | None:
     """Read the latest SSHMachine object state from the API server."""
     api = kubernetes.client.CustomObjectsApi()
@@ -1131,32 +1330,39 @@ async def sshmachine_reconcile(spec, status, name, namespace, meta, patch, **_kw
     if waited_for_lock:
         logger.info("SSHMachine %s/%s waiting for active reconcile to finish", namespace, name)
 
-    async with lock:
-        if waited_for_lock:
+    try:
+        async with lock:
+            _acquire_distributed_lock_or_requeue(namespace, name, "reconcile")
             try:
-                latest = _read_current_sshmachine(namespace, name)
-            except Exception as e:
-                logger.warning(
-                    "SSHMachine %s/%s failed to refresh live state after reconcile wait: %s",
-                    namespace,
-                    name,
-                    e,
-                )
-            else:
-                if latest is not None:
-                    spec = latest.get("spec", spec)
-                    status = latest.get("status", status)
-                    meta = latest.get("metadata", meta)
-                    logger.info("SSHMachine %s/%s refreshed live state after reconcile wait", namespace, name)
+                if waited_for_lock:
+                    try:
+                        latest = _read_current_sshmachine(namespace, name)
+                    except Exception as e:
+                        logger.warning(
+                            "SSHMachine %s/%s failed to refresh live state after reconcile wait: %s",
+                            namespace,
+                            name,
+                            e,
+                        )
+                    else:
+                        if latest is not None:
+                            spec = latest.get("spec", spec)
+                            status = latest.get("status", status)
+                            meta = latest.get("metadata", meta)
+                            logger.info("SSHMachine %s/%s refreshed live state after reconcile wait", namespace, name)
 
-        await _sshmachine_reconcile_impl(
-            spec=spec,
-            status=status,
-            name=name,
-            namespace=namespace,
-            meta=meta,
-            patch=patch,
-        )
+                await _sshmachine_reconcile_impl(
+                    spec=spec,
+                    status=status,
+                    name=name,
+                    namespace=namespace,
+                    meta=meta,
+                    patch=patch,
+                )
+            finally:
+                _release_distributed_lock_with_logging(namespace, name, "reconcile")
+    finally:
+        _cleanup_reconcile_lock(namespace, name, lock)
 
 
 @kopf.timer(
@@ -1188,44 +1394,48 @@ async def sshmachine_delete(spec, name, namespace, **_kwargs):
 
     try:
         async with lock:
-            # Release the claimed SSHHost back to the pool
-            await _release_host(spec, name, namespace)
-
-            address = spec.get("address")
-            port = spec.get("port", 22)
-            user = spec.get("user", "root")
-            ssh_key_ref = spec.get("sshKeyRef", {})
-            secret_name = ssh_key_ref.get("name")
-            secret_key = ssh_key_ref.get("key", "value")
-
-            if not address or not secret_name:
-                logger.warning("SSHMachine %s/%s missing address or sshKeyRef, skipping cleanup", namespace, name)
-                return
-
+            _acquire_distributed_lock_or_requeue(namespace, name, "delete")
             try:
-                ssh_key = await _read_ssh_key(namespace, secret_name, secret_key)
-            except Exception as e:
-                logger.warning("SSHMachine %s/%s failed to read SSH key for cleanup: %s", namespace, name, e)
-                # Don't block finalizer removal if we can't read the key
-                return
+                # Release the claimed SSHHost back to the pool
+                await _release_host(spec, name, namespace)
 
-            try:
-                async with await SSHClient.connect(address=address, port=port, user=user, key=ssh_key) as conn:
-                    cleanup_cmd = "kubeadm reset -f && rm -rf /etc/kubernetes /var/lib/kubelet"
-                    result = await conn.execute(cleanup_cmd)
-                    if result.success:
-                        logger.info("SSHMachine %s/%s cleanup succeeded on %s", namespace, name, address)
-                    else:
-                        logger.warning(
-                            "SSHMachine %s/%s cleanup failed on %s (exit=%d), allowing finalizer removal",
-                            namespace,
-                            name,
-                            address,
-                            result.exit_code,
-                        )
-            except Exception as e:
-                # Cleanup failures must not block finalizer removal
-                logger.warning("SSHMachine %s/%s SSH cleanup error on %s: %s", namespace, name, address, e)
+                address = spec.get("address")
+                port = spec.get("port", 22)
+                user = spec.get("user", "root")
+                ssh_key_ref = spec.get("sshKeyRef", {})
+                secret_name = ssh_key_ref.get("name")
+                secret_key = ssh_key_ref.get("key", "value")
+
+                if not address or not secret_name:
+                    logger.warning("SSHMachine %s/%s missing address or sshKeyRef, skipping cleanup", namespace, name)
+                    return
+
+                try:
+                    ssh_key = await _read_ssh_key(namespace, secret_name, secret_key)
+                except Exception as e:
+                    logger.warning("SSHMachine %s/%s failed to read SSH key for cleanup: %s", namespace, name, e)
+                    # Don't block finalizer removal if we can't read the key
+                    return
+
+                try:
+                    async with await SSHClient.connect(address=address, port=port, user=user, key=ssh_key) as conn:
+                        cleanup_cmd = "kubeadm reset -f && rm -rf /etc/kubernetes /var/lib/kubelet"
+                        result = await conn.execute(cleanup_cmd)
+                        if result.success:
+                            logger.info("SSHMachine %s/%s cleanup succeeded on %s", namespace, name, address)
+                        else:
+                            logger.warning(
+                                "SSHMachine %s/%s cleanup failed on %s (exit=%d), allowing finalizer removal",
+                                namespace,
+                                name,
+                                address,
+                                result.exit_code,
+                            )
+                except Exception as e:
+                    # Cleanup failures must not block finalizer removal
+                    logger.warning("SSHMachine %s/%s SSH cleanup error on %s: %s", namespace, name, address, e)
+            finally:
+                _release_distributed_lock_with_logging(namespace, name, "delete")
     finally:
         _cleanup_reconcile_lock(namespace, name, lock)
 

--- a/python/tests/test_sshmachine.py
+++ b/python/tests/test_sshmachine.py
@@ -1,12 +1,15 @@
 """Tests for SSHMachine controller."""
 
 import asyncio
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import kopf
 import pytest
 
 from capi_provider_ssh.controllers.sshmachine import (
+    _RECONCILE_LOCK_HOLDER,
+    _acquire_distributed_reconcile_lock,
     _choose_host,
     _cleanup_reconcile_lock,
     _detect_bootstrap_format,
@@ -17,6 +20,7 @@ from capi_provider_ssh.controllers.sshmachine import (
     _normalize_external_etcd,
     _prepare_bootstrap_script,
     _reconcile_lock_key,
+    _release_distributed_reconcile_lock,
     _release_host,
     sshmachine_delete,
     sshmachine_reboot,
@@ -24,6 +28,16 @@ from capi_provider_ssh.controllers.sshmachine import (
     sshmachine_reconcile_timer,
 )
 from capi_provider_ssh.ssh import SSHResult
+
+
+@pytest.fixture(autouse=True)
+def distributed_lock_success_for_handlers():
+    """Keep existing reconcile/delete tests focused by defaulting distributed lock to success."""
+    with (
+        patch("capi_provider_ssh.controllers.sshmachine._acquire_distributed_reconcile_lock", return_value=True),
+        patch("capi_provider_ssh.controllers.sshmachine._release_distributed_reconcile_lock", return_value=True),
+    ):
+        yield
 
 
 class TestHasMachineOwner:
@@ -62,6 +76,87 @@ class TestIsAlreadyProvisioned:
             "conditions": [],
         }
         assert _is_already_provisioned(status, "ssh://10.0.0.1") is True
+
+
+class TestDistributedReconcileLock:
+    def test_acquire_sets_annotation_when_unlocked(self):
+        mock_api = MagicMock()
+        mock_api.get_namespaced_custom_object.return_value = {
+            "metadata": {
+                "resourceVersion": "42",
+                "annotations": {},
+            },
+        }
+
+        with patch(
+            "capi_provider_ssh.controllers.sshmachine.kubernetes.client.CustomObjectsApi",
+            return_value=mock_api,
+        ):
+            assert _acquire_distributed_reconcile_lock("default", "m1") is True
+
+        mock_api.patch_namespaced_custom_object.assert_called_once()
+        patch_body = mock_api.patch_namespaced_custom_object.call_args.kwargs["body"]
+        lock_value = patch_body["metadata"]["annotations"]["infrastructure.cluster.x-k8s.io/reconcile-lock"]
+        holder, raw_expires = lock_value.rsplit("|", 1)
+        assert holder == _RECONCILE_LOCK_HOLDER
+        assert int(raw_expires) > int(time.time())
+
+    def test_acquire_returns_false_when_another_holder_lock_is_active(self):
+        mock_api = MagicMock()
+        mock_api.get_namespaced_custom_object.return_value = {
+            "metadata": {
+                "resourceVersion": "42",
+                "annotations": {
+                    "infrastructure.cluster.x-k8s.io/reconcile-lock": f"other-holder|{int(time.time()) + 120}",
+                },
+            },
+        }
+
+        with patch(
+            "capi_provider_ssh.controllers.sshmachine.kubernetes.client.CustomObjectsApi",
+            return_value=mock_api,
+        ):
+            assert _acquire_distributed_reconcile_lock("default", "m1") is False
+
+        mock_api.patch_namespaced_custom_object.assert_not_called()
+
+    def test_acquire_reclaims_expired_lock(self):
+        mock_api = MagicMock()
+        mock_api.get_namespaced_custom_object.return_value = {
+            "metadata": {
+                "resourceVersion": "42",
+                "annotations": {
+                    "infrastructure.cluster.x-k8s.io/reconcile-lock": "other-holder|1",
+                },
+            },
+        }
+
+        with patch(
+            "capi_provider_ssh.controllers.sshmachine.kubernetes.client.CustomObjectsApi",
+            return_value=mock_api,
+        ):
+            assert _acquire_distributed_reconcile_lock("default", "m1") is True
+
+        mock_api.patch_namespaced_custom_object.assert_called_once()
+
+    def test_release_refuses_when_lock_is_owned_by_other_holder(self):
+        mock_api = MagicMock()
+        mock_api.get_namespaced_custom_object.return_value = {
+            "metadata": {
+                "resourceVersion": "43",
+                "annotations": {
+                    "infrastructure.cluster.x-k8s.io/reconcile-lock": f"other-holder|{int(time.time()) + 120}",
+                },
+            },
+        }
+
+        with patch(
+            "capi_provider_ssh.controllers.sshmachine.kubernetes.client.CustomObjectsApi",
+            return_value=mock_api,
+        ):
+            assert _release_distributed_reconcile_lock("default", "m1") is False
+
+        mock_api.patch_namespaced_custom_object.assert_not_called()
 
 
 class TestSSHMachineReconcile:
@@ -494,6 +589,33 @@ runcmd:
         assert reconcile_impl.await_count == 2
         assert max_active == 1
 
+    @pytest.mark.asyncio
+    async def test_reconcile_requeues_when_distributed_lock_is_held(
+        self,
+        sshmachine_spec,
+        sshmachine_meta_with_owner,
+    ):
+        with (
+            patch(
+                "capi_provider_ssh.controllers.sshmachine._acquire_distributed_reconcile_lock",
+                return_value=False,
+            ),
+            patch(
+                "capi_provider_ssh.controllers.sshmachine._sshmachine_reconcile_impl",
+                new_callable=AsyncMock,
+            ) as reconcile_impl,
+            pytest.raises(kopf.TemporaryError, match="distributed reconcile lock"),
+        ):
+            await sshmachine_reconcile(
+                spec=sshmachine_spec,
+                status={},
+                name="m1",
+                namespace="default",
+                meta=sshmachine_meta_with_owner,
+                patch=kopf.Patch({}),
+            )
+        reconcile_impl.assert_not_awaited()
+
 
 class TestSSHMachineDryRun:
     @pytest.mark.asyncio
@@ -681,6 +803,22 @@ class TestSSHMachineDelete:
         ):
             # Should not raise
             await sshmachine_delete(spec=sshmachine_spec, name="m1", namespace="default")
+
+    @pytest.mark.asyncio
+    async def test_delete_requeues_when_distributed_lock_is_held(self, sshmachine_spec):
+        with (
+            patch(
+                "capi_provider_ssh.controllers.sshmachine._acquire_distributed_reconcile_lock",
+                return_value=False,
+            ),
+            patch(
+                "capi_provider_ssh.controllers.sshmachine._release_host",
+                new_callable=AsyncMock,
+            ) as release_host,
+            pytest.raises(kopf.TemporaryError, match="distributed reconcile lock"),
+        ):
+            await sshmachine_delete(spec=sshmachine_spec, name="m1", namespace="default")
+        release_host.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_delete_releases_host(self, sshmachine_spec):


### PR DESCRIPTION
## Summary
- add a cross-process per-SSHMachine reconcile lock using metadata annotations + resourceVersion CAS
- gate both reconcile and delete handlers on the distributed lock and requeue on contention
- keep the in-process asyncio lock as secondary serialization and clean up local lock mappings safely
- document lock behavior/env vars in FAQ

## Tests
- All checks passed!
- 22 files already formatted
- ssssssssssssssss........................................................ [ 64%]
.......................................                                  [100%]
95 passed, 16 skipped in 0.57s

Closes #149