### PR TITLE
fix: stabilize distributed lock holder across restarts

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -118,6 +118,10 @@ Environment controls:
 - `SSHMACHINE_DISTRIBUTED_LOCK_TTL_SECONDS` (default: `7200`)
 - `SSHMACHINE_DISTRIBUTED_LOCK_RETRY_DELAY_SECONDS` (default: `5`)
 
+Lock holder identity is stable across process restarts (`POD_NAME`/`HOSTNAME`
+based, no random suffix), so a controller restart can reclaim its own
+non-expired lock instead of waiting for TTL expiry.
+
 This protects rolling-update overlap windows where two operator instances may
 be active briefly.
 

--- a/python/capi_provider_ssh/controllers/sshmachine.py
+++ b/python/capi_provider_ssh/controllers/sshmachine.py
@@ -17,7 +17,6 @@ import re
 import shlex
 import socket
 import time
-import uuid
 
 import kopf
 import kubernetes
@@ -45,10 +44,16 @@ SSHMACHINE_DISTRIBUTED_LOCK_RETRY_DELAY_SECONDS = int(
 )
 SSHMACHINE_DISTRIBUTED_LOCK_ANNOTATION = "infrastructure.cluster.x-k8s.io/reconcile-lock"
 _RECONCILE_LOCKS: dict[str, asyncio.Lock] = {}
-_RECONCILE_LOCK_HOLDER = (
-    f"{(os.environ.get('POD_NAME') or os.environ.get('HOSTNAME') or socket.gethostname()).replace('|', '_')}"
-    f":{os.getpid()}:{uuid.uuid4().hex[:8]}"
-)
+
+
+def _build_reconcile_lock_holder() -> str:
+    """Return a stable lock holder identity across process restarts."""
+    raw_holder = os.environ.get("POD_NAME") or os.environ.get("HOSTNAME") or socket.gethostname()
+    holder = (raw_holder or "unknown").strip().replace("|", "_")
+    return holder or "unknown"
+
+
+_RECONCILE_LOCK_HOLDER = _build_reconcile_lock_holder()
 
 
 def _now_iso() -> str:

--- a/python/tests/test_sshmachine.py
+++ b/python/tests/test_sshmachine.py
@@ -10,6 +10,7 @@ import pytest
 from capi_provider_ssh.controllers.sshmachine import (
     _RECONCILE_LOCK_HOLDER,
     _acquire_distributed_reconcile_lock,
+    _build_reconcile_lock_holder,
     _choose_host,
     _cleanup_reconcile_lock,
     _detect_bootstrap_format,
@@ -79,6 +80,24 @@ class TestIsAlreadyProvisioned:
 
 
 class TestDistributedReconcileLock:
+    def test_build_reconcile_lock_holder_prefers_pod_name(self):
+        with (
+            patch.dict(
+                "os.environ",
+                {"POD_NAME": "provider-pod|a", "HOSTNAME": "provider-host"},
+                clear=True,
+            ),
+            patch("capi_provider_ssh.controllers.sshmachine.socket.gethostname", return_value="socket-host"),
+        ):
+            assert _build_reconcile_lock_holder() == "provider-pod_a"
+
+    def test_build_reconcile_lock_holder_uses_hostname_fallback(self):
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("capi_provider_ssh.controllers.sshmachine.socket.gethostname", return_value="socket-host"),
+        ):
+            assert _build_reconcile_lock_holder() == "socket-host"
+
     def test_acquire_sets_annotation_when_unlocked(self):
         mock_api = MagicMock()
         mock_api.get_namespaced_custom_object.return_value = {
@@ -134,6 +153,28 @@ class TestDistributedReconcileLock:
         with patch(
             "capi_provider_ssh.controllers.sshmachine.kubernetes.client.CustomObjectsApi",
             return_value=mock_api,
+        ):
+            assert _acquire_distributed_reconcile_lock("default", "m1") is True
+
+        mock_api.patch_namespaced_custom_object.assert_called_once()
+
+    def test_acquire_reclaims_lock_when_same_holder_and_not_expired(self):
+        mock_api = MagicMock()
+        mock_api.get_namespaced_custom_object.return_value = {
+            "metadata": {
+                "resourceVersion": "42",
+                "annotations": {
+                    "infrastructure.cluster.x-k8s.io/reconcile-lock": f"pod-a|{int(time.time()) + 120}",
+                },
+            },
+        }
+
+        with (
+            patch(
+                "capi_provider_ssh.controllers.sshmachine.kubernetes.client.CustomObjectsApi",
+                return_value=mock_api,
+            ),
+            patch("capi_provider_ssh.controllers.sshmachine._RECONCILE_LOCK_HOLDER", "pod-a"),
         ):
             assert _acquire_distributed_reconcile_lock("default", "m1") is True
 


### PR DESCRIPTION
Summary:
- remove PID/UUID churn from distributed lock holder identity
- derive holder from stable pod identity (POD_NAME/HOSTNAME) via a helper
- add tests for holder derivation and reclaim when non-expired lock owner matches holder
- document restart reclaim behavior in FAQ

Validation:
- cd python && UV_CACHE_DIR=/tmp/uv-cache uv run ruff check capi_provider_ssh tests
- cd python && UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check capi_provider_ssh tests
- cd python && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q

Closes #156