### PR TITLE
fix: re-check live state under lock before bootstrap

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -109,7 +109,9 @@ Behavior:
 
 1. Reconcile/delete handlers first acquire the in-process per-machine lock.
 2. Then they acquire the distributed lock annotation.
-3. If another pod already holds the lock, the handler requeues with
+3. Under lock, reconcile re-reads the live `SSHMachine` from the API server and
+   skips bootstrap when `status.initialization.provisioned=true`.
+4. If another pod already holds the lock, the handler requeues with
    `kopf.TemporaryError` and does not execute bootstrap/cleanup.
 
 Environment controls:

--- a/python/capi_provider_ssh/controllers/sshmachine.py
+++ b/python/capi_provider_ssh/controllers/sshmachine.py
@@ -1331,30 +1331,29 @@ async def _sshmachine_reconcile_impl(spec, status, name, namespace, meta, patch,
 async def sshmachine_reconcile(spec, status, name, namespace, meta, patch, **_kwargs):
     """Serialized SSHMachine reconcile entrypoint for create/update events."""
     lock = _get_reconcile_lock(namespace, name)
-    waited_for_lock = lock.locked()
-    if waited_for_lock:
+    if lock.locked():
         logger.info("SSHMachine %s/%s waiting for active reconcile to finish", namespace, name)
 
     try:
         async with lock:
             _acquire_distributed_lock_or_requeue(namespace, name, "reconcile")
             try:
-                if waited_for_lock:
-                    try:
-                        latest = _read_current_sshmachine(namespace, name)
-                    except Exception as e:
-                        logger.warning(
-                            "SSHMachine %s/%s failed to refresh live state after reconcile wait: %s",
-                            namespace,
-                            name,
-                            e,
-                        )
-                    else:
-                        if latest is not None:
-                            spec = latest.get("spec", spec)
-                            status = latest.get("status", status)
-                            meta = latest.get("metadata", meta)
-                            logger.info("SSHMachine %s/%s refreshed live state after reconcile wait", namespace, name)
+                # Always refresh live object state under lock to avoid stale event races.
+                try:
+                    latest = _read_current_sshmachine(namespace, name)
+                except Exception as e:
+                    logger.warning(
+                        "SSHMachine %s/%s failed to refresh live state under reconcile lock: %s",
+                        namespace,
+                        name,
+                        e,
+                    )
+                else:
+                    if latest is not None:
+                        spec = latest.get("spec", spec)
+                        status = latest.get("status", status)
+                        meta = latest.get("metadata", meta)
+                        logger.info("SSHMachine %s/%s refreshed live state under reconcile lock", namespace, name)
 
                 await _sshmachine_reconcile_impl(
                     spec=spec,

--- a/python/tests/test_sshmachine.py
+++ b/python/tests/test_sshmachine.py
@@ -585,6 +585,40 @@ runcmd:
                 lock.release()
 
     @pytest.mark.asyncio
+    async def test_reconcile_refreshes_live_state_without_wait_and_skips_stale_bootstrap(
+        self,
+        sshmachine_spec,
+        sshmachine_meta_with_owner,
+    ):
+        latest = {
+            "spec": sshmachine_spec,
+            "status": {
+                "initialization": {"provisioned": True},
+                "conditions": [{"type": "Ready", "status": "True"}],
+            },
+            "metadata": sshmachine_meta_with_owner,
+        }
+        with (
+            patch(
+                "capi_provider_ssh.controllers.sshmachine._read_current_sshmachine",
+                return_value=latest,
+            ),
+            patch(
+                "capi_provider_ssh.controllers.sshmachine._read_bootstrap_data",
+                new_callable=AsyncMock,
+            ) as read_bootstrap,
+        ):
+            await sshmachine_reconcile(
+                spec=sshmachine_spec,
+                status={},
+                name="m-race-no-wait-flag",
+                namespace="default",
+                meta=sshmachine_meta_with_owner,
+                patch=kopf.Patch({}),
+            )
+        read_bootstrap.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_handler_and_timer_reconcile_are_serialized(self, sshmachine_spec, sshmachine_meta_with_owner):
         name = "m-race-serialized"
         namespace = "default"


### PR DESCRIPTION
Summary:
- always re-read live SSHMachine state from the API server after acquiring reconcile locks
- use refreshed status/spec/meta for reconcile decisions to avoid stale event races
- add regression test for stale handler event where initial lock wait flag is false
- document live-state recheck behavior in FAQ

Validation:
- cd python && UV_CACHE_DIR=/tmp/uv-cache uv run ruff check capi_provider_ssh tests
- cd python && UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check capi_provider_ssh tests
- cd python && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q

Closes #157