### PR TITLE
fix: harden bootstrap idempotency with host sentinel

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -114,6 +114,11 @@ Behavior:
 4. If another pod already holds the lock, the handler requeues with
    `kopf.TemporaryError` and does not execute bootstrap/cleanup.
 
+Bootstrap execution also has a host-side sentinel guard:
+- On entry: if `/run/cluster-api/bootstrap-success.complete` exists, bootstrap
+  short-circuits to success without rerunning script steps.
+- On success: provider creates that sentinel file.
+
 Environment controls:
 
 - `SSHMACHINE_DISTRIBUTED_LOCK_ENABLED` (default: `true`)

--- a/python/capi_provider_ssh/controllers/sshmachine.py
+++ b/python/capi_provider_ssh/controllers/sshmachine.py
@@ -43,6 +43,8 @@ SSHMACHINE_DISTRIBUTED_LOCK_RETRY_DELAY_SECONDS = int(
     os.environ.get("SSHMACHINE_DISTRIBUTED_LOCK_RETRY_DELAY_SECONDS", "5"),
 )
 SSHMACHINE_DISTRIBUTED_LOCK_ANNOTATION = "infrastructure.cluster.x-k8s.io/reconcile-lock"
+BOOTSTRAP_SUCCESS_SENTINEL_PATH = "/run/cluster-api/bootstrap-success.complete"
+BOOTSTRAP_SENTINEL_HIT_OUTPUT = "__CAPI_PROVIDER_SSH_BOOTSTRAP_SENTINEL_HIT__"
 _RECONCILE_LOCKS: dict[str, asyncio.Lock] = {}
 
 
@@ -441,6 +443,18 @@ def _prepare_bootstrap_script(bootstrap_data: str) -> tuple[str, str]:
             raise kopf.PermanentError("bootstrap data is empty")
         return bootstrap_data, bootstrap_format
     raise kopf.PermanentError("bootstrap data format is not supported")
+
+
+def _bootstrap_execution_command() -> str:
+    """Build bootstrap command with host-side sentinel guard."""
+    sentinel_path = shlex.quote(BOOTSTRAP_SUCCESS_SENTINEL_PATH)
+    sentinel_dir = shlex.quote(posixpath.dirname(BOOTSTRAP_SUCCESS_SENTINEL_PATH))
+    sentinel_hit = shlex.quote(BOOTSTRAP_SENTINEL_HIT_OUTPUT)
+    return (
+        f"if [ -f {sentinel_path} ]; then printf '%s\\n' {sentinel_hit}; exit 0; fi && "
+        "chmod +x /tmp/bootstrap.sh && /tmp/bootstrap.sh && "
+        f"install -d -m 0755 {sentinel_dir} && touch {sentinel_path}"
+    )
 
 
 def _parse_heredoc_start(line: str) -> tuple[str, str] | None:
@@ -1281,7 +1295,7 @@ async def _sshmachine_reconcile_impl(spec, status, name, namespace, meta, patch,
             await conn.upload(bootstrap_script, "/tmp/bootstrap.sh")  # noqa: S108
 
             # Execute bootstrap
-            result = await conn.execute("chmod +x /tmp/bootstrap.sh && /tmp/bootstrap.sh")  # noqa: S108
+            result = await conn.execute(_bootstrap_execution_command())  # noqa: S108
 
             if not result.success:
                 patch.status["failureReason"] = "BootstrapFailed"
@@ -1290,6 +1304,14 @@ async def _sshmachine_reconcile_impl(spec, status, name, namespace, meta, patch,
                     _not_ready_condition("BootstrapFailed", f"Bootstrap script exited with code {result.exit_code}"),
                 ]
                 raise kopf.TemporaryError(f"Bootstrap failed (exit {result.exit_code})", delay=30)
+
+            if BOOTSTRAP_SENTINEL_HIT_OUTPUT in (result.stdout or ""):
+                logger.info(
+                    "SSHMachine %s/%s bootstrap sentinel already present on %s, skipping bootstrap script",
+                    namespace,
+                    name,
+                    address,
+                )
 
     except kopf.TemporaryError:
         raise
@@ -1423,7 +1445,10 @@ async def sshmachine_delete(spec, name, namespace, **_kwargs):
 
                 try:
                     async with await SSHClient.connect(address=address, port=port, user=user, key=ssh_key) as conn:
-                        cleanup_cmd = "kubeadm reset -f && rm -rf /etc/kubernetes /var/lib/kubelet"
+                        cleanup_cmd = (
+                            "kubeadm reset -f && rm -rf /etc/kubernetes /var/lib/kubelet "
+                            f"{shlex.quote(BOOTSTRAP_SUCCESS_SENTINEL_PATH)}"
+                        )
                         result = await conn.execute(cleanup_cmd)
                         if result.success:
                             logger.info("SSHMachine %s/%s cleanup succeeded on %s", namespace, name, address)

--- a/python/tests/test_sshmachine.py
+++ b/python/tests/test_sshmachine.py
@@ -9,7 +9,10 @@ import pytest
 
 from capi_provider_ssh.controllers.sshmachine import (
     _RECONCILE_LOCK_HOLDER,
+    BOOTSTRAP_SENTINEL_HIT_OUTPUT,
+    BOOTSTRAP_SUCCESS_SENTINEL_PATH,
     _acquire_distributed_reconcile_lock,
+    _bootstrap_execution_command,
     _build_reconcile_lock_holder,
     _choose_host,
     _cleanup_reconcile_lock,
@@ -200,6 +203,15 @@ class TestDistributedReconcileLock:
         mock_api.patch_namespaced_custom_object.assert_not_called()
 
 
+class TestBootstrapSentinelCommand:
+    def test_bootstrap_execution_command_includes_guard_and_touch(self):
+        cmd = _bootstrap_execution_command()
+        assert BOOTSTRAP_SUCCESS_SENTINEL_PATH in cmd
+        assert BOOTSTRAP_SENTINEL_HIT_OUTPUT in cmd
+        assert f"touch {BOOTSTRAP_SUCCESS_SENTINEL_PATH}" in cmd
+        assert "chmod +x /tmp/bootstrap.sh && /tmp/bootstrap.sh" in cmd
+
+
 class TestSSHMachineReconcile:
     @pytest.mark.asyncio
     async def test_paused_skips(self, sshmachine_meta_with_owner):
@@ -349,6 +361,51 @@ class TestSSHMachineReconcile:
             assert patch_obj["spec"]["providerID"] == "ssh://100.64.0.10"
             assert patch_obj["status"]["addresses"][0]["address"] == "100.64.0.10"
             assert patch_obj["status"]["failureReason"] is None
+            executed_cmd = mock_conn.execute.call_args[0][0]
+            assert BOOTSTRAP_SUCCESS_SENTINEL_PATH in executed_cmd
+            assert BOOTSTRAP_SENTINEL_HIT_OUTPUT in executed_cmd
+
+    @pytest.mark.asyncio
+    async def test_bootstrap_sentinel_short_circuit_logs_skip(self, sshmachine_spec, sshmachine_meta_with_owner):
+        mock_conn = AsyncMock()
+        mock_conn.execute.return_value = SSHResult(exit_code=0, stdout=f"{BOOTSTRAP_SENTINEL_HIT_OUTPUT}\n", stderr="")
+        mock_conn.upload = AsyncMock()
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "capi_provider_ssh.controllers.sshmachine._read_bootstrap_data",
+                new_callable=AsyncMock,
+                return_value="#!/bin/bash\necho bootstrap",
+            ),
+            patch(
+                "capi_provider_ssh.controllers.sshmachine._read_ssh_key",
+                new_callable=AsyncMock,
+                return_value="fake-key",
+            ),
+            patch(
+                "capi_provider_ssh.controllers.sshmachine.SSHClient.connect",
+                new_callable=AsyncMock,
+                return_value=mock_conn,
+            ),
+            patch("capi_provider_ssh.controllers.sshmachine.logger") as mock_logger,
+        ):
+            patch_obj = kopf.Patch({})
+            await sshmachine_reconcile(
+                spec=sshmachine_spec,
+                status={},
+                name="m-sentinel",
+                namespace="default",
+                meta=sshmachine_meta_with_owner,
+                patch=patch_obj,
+            )
+        assert patch_obj["status"]["initialization"]["provisioned"] is True
+        assert any(
+            "bootstrap sentinel already present" in call.args[0]
+            for call in mock_logger.info.call_args_list
+            if call.args
+        )
 
     @pytest.mark.asyncio
     async def test_bootstrap_failure_sets_failure_status(self, sshmachine_spec, sshmachine_meta_with_owner):
@@ -860,6 +917,7 @@ class TestSSHMachineDelete:
             mock_conn.execute.assert_called_once()
             cmd = mock_conn.execute.call_args[0][0]
             assert "kubeadm reset -f" in cmd
+            assert BOOTSTRAP_SUCCESS_SENTINEL_PATH in cmd
 
     @pytest.mark.asyncio
     async def test_delete_ssh_failure_does_not_raise(self, sshmachine_spec):


### PR DESCRIPTION
Summary:
- add host-side bootstrap sentinel guard at /run/cluster-api/bootstrap-success.complete
- short-circuit bootstrap command when sentinel exists and log sentinel hit path
- create sentinel only after successful bootstrap execution
- clear sentinel during SSHMachine delete cleanup
- add unit/regression tests for command guard, sentinel short-circuit, and cleanup command
- document sentinel behavior in FAQ

Validation:
- cd python && UV_CACHE_DIR=/tmp/uv-cache uv run ruff check capi_provider_ssh tests
- cd python && UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check capi_provider_ssh tests
- cd python && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q

Closes #144