### PR TITLE
fix: skip stale SSHMachine reconcile events by UID

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -109,8 +109,9 @@ Behavior:
 
 1. Reconcile/delete handlers first acquire the in-process per-machine lock.
 2. Then they acquire the distributed lock annotation.
-3. Under lock, reconcile re-reads the live `SSHMachine` from the API server and
-   skips bootstrap when `status.initialization.provisioned=true`.
+3. Under lock, reconcile re-reads the live `SSHMachine` from the API server
+   when the event contains `metadata.uid`, and skips bootstrap when
+   `status.initialization.provisioned=true`.
 4. If another pod already holds the lock, the handler requeues with
    `kopf.TemporaryError` and does not execute bootstrap/cleanup.
 
@@ -118,6 +119,11 @@ Bootstrap execution also has a host-side sentinel guard:
 - On entry: if `/run/cluster-api/bootstrap-success.complete` exists, bootstrap
   short-circuits to success without rerunning script steps.
 - On success: provider creates that sentinel file.
+
+Reconcile also validates object identity under lock: if the live object is gone
+or the live `metadata.uid` differs from the event UID, the handler exits
+without bootstrap. This prevents stale timer/update callbacks from acting on a
+deleted/recreated `SSHMachine` with the same name.
 
 Environment controls:
 

--- a/python/capi_provider_ssh/controllers/sshmachine.py
+++ b/python/capi_provider_ssh/controllers/sshmachine.py
@@ -1360,22 +1360,47 @@ async def sshmachine_reconcile(spec, status, name, namespace, meta, patch, **_kw
         async with lock:
             _acquire_distributed_lock_or_requeue(namespace, name, "reconcile")
             try:
-                # Always refresh live object state under lock to avoid stale event races.
-                try:
-                    latest = _read_current_sshmachine(namespace, name)
-                except Exception as e:
-                    logger.warning(
-                        "SSHMachine %s/%s failed to refresh live state under reconcile lock: %s",
-                        namespace,
-                        name,
-                        e,
-                    )
-                else:
-                    if latest is not None:
+                # Refresh live object state when an event UID is available to reject stale timer/handler events.
+                event_uid = meta.get("uid")
+                if event_uid:
+                    try:
+                        latest = _read_current_sshmachine(namespace, name)
+                    except Exception as e:
+                        raise kopf.TemporaryError(
+                            f"failed to refresh live SSHMachine state under reconcile lock: {e}",
+                            delay=15,
+                        ) from e
+                    else:
+                        if latest is None:
+                            logger.info(
+                                "SSHMachine %s/%s no longer exists while reconciling, skipping stale event",
+                                namespace,
+                                name,
+                            )
+                            return
+
+                        live_meta = latest.get("metadata", {})
+                        live_uid = live_meta.get("uid")
+                        if live_uid and event_uid != live_uid:
+                            logger.info(
+                                "SSHMachine %s/%s stale reconcile event detected (eventUID=%s liveUID=%s), skipping",
+                                namespace,
+                                name,
+                                event_uid,
+                                live_uid,
+                            )
+                            return
+
                         spec = latest.get("spec", spec)
                         status = latest.get("status", status)
-                        meta = latest.get("metadata", meta)
+                        meta = live_meta or meta
                         logger.info("SSHMachine %s/%s refreshed live state under reconcile lock", namespace, name)
+                else:
+                    logger.debug(
+                        "SSHMachine %s/%s reconcile event has no metadata.uid, skipping stale-event UID validation",
+                        namespace,
+                        name,
+                    )
 
                 await _sshmachine_reconcile_impl(
                     spec=spec,

--- a/python/tests/test_sshmachine.py
+++ b/python/tests/test_sshmachine.py
@@ -594,6 +594,7 @@ runcmd:
         sshmachine_spec,
         sshmachine_meta_with_owner,
     ):
+        event_meta = {**sshmachine_meta_with_owner, "uid": "uid-race-refresh"}
         name = "m-race-refresh"
         namespace = "default"
         lock = _get_reconcile_lock(namespace, name)
@@ -605,7 +606,7 @@ runcmd:
                 "initialization": {"provisioned": True},
                 "conditions": [{"type": "Ready", "status": "True"}],
             },
-            "metadata": sshmachine_meta_with_owner,
+            "metadata": event_meta,
         }
 
         task = None
@@ -627,7 +628,7 @@ runcmd:
                         status={},
                         name=name,
                         namespace=namespace,
-                        meta=sshmachine_meta_with_owner,
+                        meta=event_meta,
                         patch=patch_obj,
                     ),
                 )
@@ -647,13 +648,14 @@ runcmd:
         sshmachine_spec,
         sshmachine_meta_with_owner,
     ):
+        event_meta = {**sshmachine_meta_with_owner, "uid": "uid-race-no-wait"}
         latest = {
             "spec": sshmachine_spec,
             "status": {
                 "initialization": {"provisioned": True},
                 "conditions": [{"type": "Ready", "status": "True"}],
             },
-            "metadata": sshmachine_meta_with_owner,
+            "metadata": event_meta,
         }
         with (
             patch(
@@ -670,10 +672,64 @@ runcmd:
                 status={},
                 name="m-race-no-wait-flag",
                 namespace="default",
-                meta=sshmachine_meta_with_owner,
+                meta=event_meta,
                 patch=kopf.Patch({}),
             )
         read_bootstrap.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reconcile_skips_when_live_object_missing(self, sshmachine_spec, sshmachine_meta_with_owner):
+        with (
+            patch(
+                "capi_provider_ssh.controllers.sshmachine._read_current_sshmachine",
+                return_value=None,
+            ),
+            patch(
+                "capi_provider_ssh.controllers.sshmachine._sshmachine_reconcile_impl",
+                new_callable=AsyncMock,
+            ) as reconcile_impl,
+        ):
+            await sshmachine_reconcile(
+                spec=sshmachine_spec,
+                status={},
+                name="m-stale-missing",
+                namespace="default",
+                meta={**sshmachine_meta_with_owner, "uid": "uid-old"},
+                patch=kopf.Patch({}),
+            )
+        reconcile_impl.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reconcile_skips_when_event_uid_differs_from_live_uid(
+        self,
+        sshmachine_spec,
+        sshmachine_meta_with_owner,
+    ):
+        latest = {
+            "spec": sshmachine_spec,
+            "status": {},
+            "metadata": {**sshmachine_meta_with_owner, "uid": "uid-live"},
+        }
+
+        with (
+            patch(
+                "capi_provider_ssh.controllers.sshmachine._read_current_sshmachine",
+                return_value=latest,
+            ),
+            patch(
+                "capi_provider_ssh.controllers.sshmachine._sshmachine_reconcile_impl",
+                new_callable=AsyncMock,
+            ) as reconcile_impl,
+        ):
+            await sshmachine_reconcile(
+                spec=sshmachine_spec,
+                status={},
+                name="m-stale-uid",
+                namespace="default",
+                meta={**sshmachine_meta_with_owner, "uid": "uid-old"},
+                patch=kopf.Patch({}),
+            )
+        reconcile_impl.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_handler_and_timer_reconcile_are_serialized(self, sshmachine_spec, sshmachine_meta_with_owner):


### PR DESCRIPTION
## Summary
- guard reconcile identity checks with event `metadata.uid` presence
- under lock, re-read live SSHMachine and skip stale events when object is gone or UID changed
- keep reconcile safe by requeueing when live state refresh fails
- add tests for missing live object and UID mismatch stale events
- document UID-based stale-event protection in FAQ

## Testing
- `UV_CACHE_DIR=/tmp/uv-cache uv run python -m ruff check capi_provider_ssh tests`
- `UV_CACHE_DIR=/tmp/uv-cache uv run python -m ruff format --check capi_provider_ssh tests`
- `UV_CACHE_DIR=/tmp/uv-cache uv run python -m pytest -q`

Closes #146
