### PR TITLE
fix(sshmachine): classify bootstrap failure phases and diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Re-read live SSHMachine state before bootstrap 
 - Add host-side bootstrap sentinel guard
 - Skip stale SSHMachine reconcile events by UID
+- Classify bootstrap failures by phase and persist sanitized diagnostics
 
 ### Miscellaneous
 

--- a/python/capi_provider_ssh/controllers/sshmachine.py
+++ b/python/capi_provider_ssh/controllers/sshmachine.py
@@ -23,7 +23,7 @@ import kubernetes
 import yaml
 
 from capi_provider_ssh import API_GROUP, API_VERSION
-from capi_provider_ssh.ssh import SSHClient
+from capi_provider_ssh.ssh import SSHClient, SSHResult
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +45,18 @@ SSHMACHINE_DISTRIBUTED_LOCK_RETRY_DELAY_SECONDS = int(
 SSHMACHINE_DISTRIBUTED_LOCK_ANNOTATION = "infrastructure.cluster.x-k8s.io/reconcile-lock"
 BOOTSTRAP_SUCCESS_SENTINEL_PATH = "/run/cluster-api/bootstrap-success.complete"
 BOOTSTRAP_SENTINEL_HIT_OUTPUT = "__CAPI_PROVIDER_SSH_BOOTSTRAP_SENTINEL_HIT__"
+BOOTSTRAP_PHASE_REASON_MAP = {
+    "reset": "BootstrapResetFailed",
+    "init": "BootstrapInitFailed",
+    "join": "BootstrapJoinFailed",
+}
+BOOTSTRAP_DIAGNOSTIC_MAX_EXCERPT = 240
+BOOTSTRAP_DIAGNOSTIC_REDACTIONS = (
+    (re.compile(r"(?i)(--token(?:=|\s+))\S+"), r"\1[REDACTED]"),
+    (re.compile(r"(?i)(--certificate-key(?:=|\s+))\S+"), r"\1[REDACTED]"),
+    (re.compile(r"(?i)(--discovery-token-ca-cert-hash(?:=|\s+))\S+"), r"\1[REDACTED]"),
+    (re.compile(r"(?i)\b(token|certificate-key|discovery-token-ca-cert-hash)\b\s*[:=]\s*\S+"), r"\1=[REDACTED]"),
+)
 _RECONCILE_LOCKS: dict[str, asyncio.Lock] = {}
 
 
@@ -455,6 +467,77 @@ def _bootstrap_execution_command() -> str:
         "chmod +x /tmp/bootstrap.sh && /tmp/bootstrap.sh && "
         f"install -d -m 0755 {sentinel_dir} && touch {sentinel_path}"
     )
+
+
+def _sanitize_bootstrap_diagnostic_text(text: str) -> str:
+    """Redact sensitive kubeadm values before storing in status."""
+    sanitized = text
+    for pattern, replacement in BOOTSTRAP_DIAGNOSTIC_REDACTIONS:
+        sanitized = pattern.sub(replacement, sanitized)
+    return re.sub(r"\s+", " ", sanitized).strip()
+
+
+def _excerpt_bootstrap_output(result: SSHResult) -> str:
+    """Return a compact, sanitized stderr/stdout excerpt for diagnostics."""
+    for chunk in (result.stderr, result.stdout):
+        excerpt = _sanitize_bootstrap_diagnostic_text(chunk or "")
+        if not excerpt:
+            continue
+        if len(excerpt) <= BOOTSTRAP_DIAGNOSTIC_MAX_EXCERPT:
+            return excerpt
+        return f"{excerpt[: BOOTSTRAP_DIAGNOSTIC_MAX_EXCERPT - 3].rstrip()}..."
+    return ""
+
+
+def _detect_bootstrap_failure_phase(stderr: str, stdout: str, bootstrap_script: str) -> str:
+    """Infer which bootstrap phase failed from output signatures and script content."""
+    combined_output = "\n".join(part for part in (stderr, stdout) if part)
+    phase_signatures = (
+        ("reset", (r"\bkubeadm\s+reset\b", r"\[reset\]", r"\bfailed\s+to\s+reset\b")),
+        ("init", (r"\bkubeadm\s+init\b", r"\[init\]", r"\binitconfiguration\b", r"\bcontrol-plane\b")),
+        ("join", (r"\bkubeadm\s+join\b", r"\[join\]", r"\bdiscovery-token\b", r"\bnode\s+join\b")),
+    )
+    for phase, signatures in phase_signatures:
+        if any(re.search(signature, combined_output, flags=re.IGNORECASE) for signature in signatures):
+            return phase
+
+    script_lower = bootstrap_script.lower()
+    has_init = "kubeadm init" in script_lower
+    has_join = "kubeadm join" in script_lower
+    has_reset = "kubeadm reset" in script_lower
+
+    # Fallback prefers the primary operation over optional cleanup commands.
+    if has_init and not has_join:
+        return "init"
+    if has_join and not has_init:
+        return "join"
+    if has_reset and not (has_init or has_join):
+        return "reset"
+    if has_init:
+        return "init"
+    if has_join:
+        return "join"
+    if has_reset:
+        return "reset"
+    return "unknown"
+
+
+def _classify_bootstrap_failure(result: SSHResult, bootstrap_script: str) -> tuple[str, str, str, str]:
+    """Classify bootstrap failures and build safe status diagnostics."""
+    phase = _detect_bootstrap_failure_phase(result.stderr, result.stdout, bootstrap_script)
+    reason = BOOTSTRAP_PHASE_REASON_MAP.get(phase, "BootstrapFailed")
+    stderr_excerpt = _excerpt_bootstrap_output(result)
+    phase_label = {
+        "reset": "reset phase",
+        "init": "init phase",
+        "join": "join phase",
+    }.get(phase, "execution")
+    failure_message = f"Bootstrap {phase_label} failed (exit {result.exit_code})"
+    if stderr_excerpt:
+        failure_message = f"{failure_message}: {stderr_excerpt}"
+    else:
+        failure_message = f"{failure_message}. Inspect kubeadm and cloud-init logs on the host."
+    return reason, phase, failure_message, stderr_excerpt
 
 
 def _parse_heredoc_start(line: str) -> tuple[str, str] | None:
@@ -1174,6 +1257,9 @@ async def _sshmachine_reconcile_impl(spec, status, name, namespace, meta, patch,
         logger.info("SSHMachine %s/%s already provisioned (providerID=%s)", namespace, name, provider_id)
         return
 
+    # Keep diagnostics current and prevent stale bootstrap failure details.
+    patch.status["bootstrapDiagnostics"] = None
+
     # Wait for bootstrap data
     bootstrap_data = await _read_bootstrap_data(namespace, machine_name)
     if not bootstrap_data:
@@ -1265,6 +1351,7 @@ async def _sshmachine_reconcile_impl(spec, status, name, namespace, meta, patch,
                 f"Dry-run passed: SSH to {address}, bootstrap data ready",
             ),
         ]
+        patch.status["bootstrapDiagnostics"] = None
         patch.status["failureReason"] = None
         patch.status["failureMessage"] = None
         logger.info("SSHMachine %s/%s dry-run passed", namespace, name)
@@ -1298,12 +1385,24 @@ async def _sshmachine_reconcile_impl(spec, status, name, namespace, meta, patch,
             result = await conn.execute(_bootstrap_execution_command())  # noqa: S108
 
             if not result.success:
-                patch.status["failureReason"] = "BootstrapFailed"
-                patch.status["failureMessage"] = f"Bootstrap script exited {result.exit_code}"
+                failure_reason, failure_phase, failure_message, stderr_excerpt = _classify_bootstrap_failure(
+                    result,
+                    bootstrap_script,
+                )
+                patch.status["failureReason"] = failure_reason
+                patch.status["failureMessage"] = failure_message
+                patch.status["bootstrapDiagnostics"] = {
+                    "phase": failure_phase,
+                    "exitCode": result.exit_code,
+                    "stderrExcerpt": stderr_excerpt,
+                }
                 patch.status["conditions"] = [
-                    _not_ready_condition("BootstrapFailed", f"Bootstrap script exited with code {result.exit_code}"),
+                    _not_ready_condition(failure_reason, failure_message),
                 ]
-                raise kopf.TemporaryError(f"Bootstrap failed (exit {result.exit_code})", delay=30)
+                raise kopf.TemporaryError(
+                    f"Bootstrap failed ({failure_reason}, exit {result.exit_code})",
+                    delay=30,
+                )
 
             if BOOTSTRAP_SENTINEL_HIT_OUTPUT in (result.stdout or ""):
                 logger.info(
@@ -1342,6 +1441,7 @@ async def _sshmachine_reconcile_impl(spec, status, name, namespace, meta, patch,
         _ready_condition(f"Machine {address} provisioned with providerID {provider_id}"),
     ]
     # Clear any previous failure state
+    patch.status["bootstrapDiagnostics"] = None
     patch.status["failureReason"] = None
     patch.status["failureMessage"] = None
 

--- a/python/tests/test_sshmachine.py
+++ b/python/tests/test_sshmachine.py
@@ -15,6 +15,7 @@ from capi_provider_ssh.controllers.sshmachine import (
     _bootstrap_execution_command,
     _build_reconcile_lock_holder,
     _choose_host,
+    _classify_bootstrap_failure,
     _cleanup_reconcile_lock,
     _detect_bootstrap_format,
     _get_reconcile_lock,
@@ -210,6 +211,48 @@ class TestBootstrapSentinelCommand:
         assert BOOTSTRAP_SENTINEL_HIT_OUTPUT in cmd
         assert f"touch {BOOTSTRAP_SUCCESS_SENTINEL_PATH}" in cmd
         assert "chmod +x /tmp/bootstrap.sh && /tmp/bootstrap.sh" in cmd
+
+
+class TestBootstrapFailureClassification:
+    def test_classify_detects_reset_from_stderr(self):
+        result = SSHResult(exit_code=2, stdout="", stderr="[reset] failed to reset node")
+        reason, phase, message, stderr_excerpt = _classify_bootstrap_failure(result, "#!/bin/bash\necho bootstrap")
+        assert reason == "BootstrapResetFailed"
+        assert phase == "reset"
+        assert "exit 2" in message
+        assert "failed to reset node" in stderr_excerpt
+
+    def test_classify_falls_back_to_bootstrap_script_phase(self):
+        result = SSHResult(exit_code=1, stdout="", stderr="command failed")
+        reason, phase, message, stderr_excerpt = _classify_bootstrap_failure(
+            result, "#!/bin/bash\nkubeadm join 10.0.0.1:6443"
+        )
+        assert reason == "BootstrapJoinFailed"
+        assert phase == "join"
+        assert "join phase" in message
+        assert stderr_excerpt == "command failed"
+
+    def test_classify_redacts_sensitive_kubeadm_flags(self):
+        stderr = (
+            "kubeadm join 10.0.0.1:6443 "
+            "--token abc.def "
+            "--discovery-token-ca-cert-hash sha256:deadbeef "
+            "--certificate-key 0123456789abcdef"
+        )
+        result = SSHResult(exit_code=1, stdout="", stderr=stderr)
+        _, _, message, stderr_excerpt = _classify_bootstrap_failure(result, "#!/bin/bash\nkubeadm join 10.0.0.1:6443")
+        assert "[REDACTED]" in message
+        assert "abc.def" not in message
+        assert "sha256:deadbeef" not in message
+        assert "0123456789abcdef" not in message
+        assert "[REDACTED]" in stderr_excerpt
+
+    def test_classify_uses_generic_reason_when_phase_unknown(self):
+        result = SSHResult(exit_code=3, stdout="", stderr="bootstrap failed without phase markers")
+        reason, phase, message, _ = _classify_bootstrap_failure(result, "#!/bin/bash\necho bootstrap")
+        assert reason == "BootstrapFailed"
+        assert phase == "unknown"
+        assert "Bootstrap execution failed" in message
 
 
 class TestSSHMachineReconcile:
@@ -442,7 +485,11 @@ class TestSSHMachineReconcile:
                     meta=sshmachine_meta_with_owner,
                     patch=patch_obj,
                 )
-            assert patch_obj["status"]["failureReason"] == "BootstrapFailed"
+            assert patch_obj["status"]["failureReason"] == "BootstrapJoinFailed"
+            assert patch_obj["status"]["bootstrapDiagnostics"]["phase"] == "join"
+            assert patch_obj["status"]["bootstrapDiagnostics"]["exitCode"] == 1
+            assert patch_obj["status"]["bootstrapDiagnostics"]["stderrExcerpt"] == "error"
+            assert "Bootstrap join phase failed" in patch_obj["status"]["failureMessage"]
 
     @pytest.mark.asyncio
     async def test_successful_bootstrap_with_cloud_config(self, sshmachine_spec, sshmachine_meta_with_owner):

--- a/shared/crds/sshmachine.yaml
+++ b/shared/crds/sshmachine.yaml
@@ -183,6 +183,18 @@ spec:
                   type: string
                 failureMessage:
                   type: string
+                bootstrapDiagnostics:
+                  type: object
+                  properties:
+                    phase:
+                      type: string
+                      description: Bootstrap phase inferred from output signatures (reset/init/join/unknown).
+                    exitCode:
+                      type: integer
+                      description: Exit code returned by the bootstrap script command.
+                    stderrExcerpt:
+                      type: string
+                      description: Sanitized stderr/stdout excerpt for concise failure triage.
                 remediation:
                   type: object
                   properties:


### PR DESCRIPTION
## Summary

- classify bootstrap failures into reset/init/join specific failureReason values
- add sanitized bootstrap diagnostics (phase, exitCode, stderrExcerpt) to status
- add unit coverage for mapping and redaction, and update reconcile failure expectations
- add SSHMachine CRD status schema for bootstrapDiagnostics\n\n
 
## Testing

- UV_CACHE_DIR=/tmp/uv-cache uv run ruff check capi_provider_ssh/controllers/sshmachine.py tests/test_sshmachine.py
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest

Closes #147