### PR TITLE
fix(sshmachine): gate Ready on post-bootstrap kubelet checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add host-side bootstrap sentinel guard
 - Skip stale SSHMachine reconcile events by UID
 - **sshmachine:** Classify bootstrap failure phases
+- **sshmachine:** Gate Ready status on post-bootstrap kubelet checks
 
 ### Miscellaneous
 

--- a/python/capi_provider_ssh/controllers/sshmachine.py
+++ b/python/capi_provider_ssh/controllers/sshmachine.py
@@ -45,6 +45,7 @@ SSHMACHINE_DISTRIBUTED_LOCK_RETRY_DELAY_SECONDS = int(
 SSHMACHINE_DISTRIBUTED_LOCK_ANNOTATION = "infrastructure.cluster.x-k8s.io/reconcile-lock"
 BOOTSTRAP_SUCCESS_SENTINEL_PATH = "/run/cluster-api/bootstrap-success.complete"
 BOOTSTRAP_SENTINEL_HIT_OUTPUT = "__CAPI_PROVIDER_SSH_BOOTSTRAP_SENTINEL_HIT__"
+KUBELET_READY_SENTINEL_OUTPUT = "__CAPI_PROVIDER_SSH_KUBELET_READY__"
 BOOTSTRAP_PHASE_REASON_MAP = {
     "reset": "BootstrapResetFailed",
     "init": "BootstrapInitFailed",
@@ -469,6 +470,24 @@ def _bootstrap_execution_command() -> str:
     )
 
 
+def _post_bootstrap_readiness_command() -> str:
+    """Check host-side kubelet readiness after bootstrap exits successfully."""
+    kubelet_ready = shlex.quote(KUBELET_READY_SENTINEL_OUTPUT)
+    return (
+        "if ! command -v systemctl >/dev/null 2>&1; then "
+        "echo 'systemctl command not found on host' >&2; "
+        "exit 31; "
+        "fi && "
+        "if systemctl is-active --quiet kubelet; then "
+        f"printf '%s\\n' {kubelet_ready}; "
+        "else "
+        "(systemctl is-active kubelet || true) >&2; "
+        "(systemctl --no-pager --full status kubelet 2>/dev/null | tail -n 20 || true) >&2; "
+        "exit 32; "
+        "fi"
+    )
+
+
 def _sanitize_bootstrap_diagnostic_text(text: str) -> str:
     """Redact sensitive kubeadm values before storing in status."""
     sanitized = text
@@ -477,7 +496,7 @@ def _sanitize_bootstrap_diagnostic_text(text: str) -> str:
     return re.sub(r"\s+", " ", sanitized).strip()
 
 
-def _excerpt_bootstrap_output(result: SSHResult) -> str:
+def _excerpt_command_output(result: SSHResult) -> str:
     """Return a compact, sanitized stderr/stdout excerpt for diagnostics."""
     for chunk in (result.stderr, result.stdout):
         excerpt = _sanitize_bootstrap_diagnostic_text(chunk or "")
@@ -526,7 +545,7 @@ def _classify_bootstrap_failure(result: SSHResult, bootstrap_script: str) -> tup
     """Classify bootstrap failures and build safe status diagnostics."""
     phase = _detect_bootstrap_failure_phase(result.stderr, result.stdout, bootstrap_script)
     reason = BOOTSTRAP_PHASE_REASON_MAP.get(phase, "BootstrapFailed")
-    stderr_excerpt = _excerpt_bootstrap_output(result)
+    stderr_excerpt = _excerpt_command_output(result)
     phase_label = {
         "reset": "reset phase",
         "init": "init phase",
@@ -538,6 +557,17 @@ def _classify_bootstrap_failure(result: SSHResult, bootstrap_script: str) -> tup
     else:
         failure_message = f"{failure_message}. Inspect kubeadm and cloud-init logs on the host."
     return reason, phase, failure_message, stderr_excerpt
+
+
+def _classify_kubelet_not_ready(result: SSHResult) -> tuple[str, str]:
+    """Build status reason/message when post-bootstrap kubelet checks fail."""
+    output_excerpt = _excerpt_command_output(result)
+    failure_message = f"Bootstrap completed, but kubelet is not ready (exit {result.exit_code})"
+    if output_excerpt:
+        failure_message = f"{failure_message}: {output_excerpt}"
+    else:
+        failure_message = f"{failure_message}. Waiting for kubelet to become active."
+    return "KubeletNotReady", failure_message
 
 
 def _parse_heredoc_start(line: str) -> tuple[str, str] | None:
@@ -1410,6 +1440,25 @@ async def _sshmachine_reconcile_impl(spec, status, name, namespace, meta, patch,
                     namespace,
                     name,
                     address,
+                )
+
+            readiness_result = await conn.execute(_post_bootstrap_readiness_command())  # noqa: S108
+            if not readiness_result.success:
+                failure_reason, failure_message = _classify_kubelet_not_ready(readiness_result)
+                patch.status["initialization"] = {"provisioned": False}
+                patch.status["failureReason"] = failure_reason
+                patch.status["failureMessage"] = failure_message
+                patch.status["conditions"] = [
+                    _not_ready_condition(failure_reason, failure_message),
+                    _info_condition(
+                        "Bootstrapped",
+                        "BootstrapCompleted",
+                        "Bootstrap script completed; waiting for kubelet readiness checks to pass",
+                    ),
+                ]
+                raise kopf.TemporaryError(
+                    f"Post-bootstrap readiness check failed ({failure_reason}, exit {readiness_result.exit_code})",
+                    delay=30,
                 )
 
     except kopf.TemporaryError:

--- a/python/tests/test_sshmachine.py
+++ b/python/tests/test_sshmachine.py
@@ -16,6 +16,7 @@ from capi_provider_ssh.controllers.sshmachine import (
     _build_reconcile_lock_holder,
     _choose_host,
     _classify_bootstrap_failure,
+    _classify_kubelet_not_ready,
     _cleanup_reconcile_lock,
     _detect_bootstrap_format,
     _get_reconcile_lock,
@@ -23,6 +24,7 @@ from capi_provider_ssh.controllers.sshmachine import (
     _inject_external_etcd_into_bootstrap_data,
     _is_already_provisioned,
     _normalize_external_etcd,
+    _post_bootstrap_readiness_command,
     _prepare_bootstrap_script,
     _reconcile_lock_key,
     _release_distributed_reconcile_lock,
@@ -212,6 +214,11 @@ class TestBootstrapSentinelCommand:
         assert f"touch {BOOTSTRAP_SUCCESS_SENTINEL_PATH}" in cmd
         assert "chmod +x /tmp/bootstrap.sh && /tmp/bootstrap.sh" in cmd
 
+    def test_post_bootstrap_readiness_command_checks_kubelet(self):
+        cmd = _post_bootstrap_readiness_command()
+        assert "systemctl is-active --quiet kubelet" in cmd
+        assert "systemctl command not found on host" in cmd
+
 
 class TestBootstrapFailureClassification:
     def test_classify_detects_reset_from_stderr(self):
@@ -253,6 +260,13 @@ class TestBootstrapFailureClassification:
         assert reason == "BootstrapFailed"
         assert phase == "unknown"
         assert "Bootstrap execution failed" in message
+
+    def test_classify_kubelet_not_ready(self):
+        result = SSHResult(exit_code=32, stdout="", stderr="inactive")
+        reason, message = _classify_kubelet_not_ready(result)
+        assert reason == "KubeletNotReady"
+        assert "Bootstrap completed, but kubelet is not ready" in message
+        assert "inactive" in message
 
 
 class TestSSHMachineReconcile:
@@ -392,6 +406,10 @@ class TestSSHMachineReconcile:
             ),
         ):
             patch_obj = kopf.Patch({})
+            mock_conn.execute.side_effect = [
+                SSHResult(exit_code=0, stdout="ok", stderr=""),
+                SSHResult(exit_code=0, stdout="active", stderr=""),
+            ]
             await sshmachine_reconcile(
                 spec=sshmachine_spec,
                 status={},
@@ -404,14 +422,20 @@ class TestSSHMachineReconcile:
             assert patch_obj["spec"]["providerID"] == "ssh://100.64.0.10"
             assert patch_obj["status"]["addresses"][0]["address"] == "100.64.0.10"
             assert patch_obj["status"]["failureReason"] is None
-            executed_cmd = mock_conn.execute.call_args[0][0]
-            assert BOOTSTRAP_SUCCESS_SENTINEL_PATH in executed_cmd
-            assert BOOTSTRAP_SENTINEL_HIT_OUTPUT in executed_cmd
+            assert mock_conn.execute.await_count == 2
+            bootstrap_cmd = mock_conn.execute.call_args_list[0][0][0]
+            readiness_cmd = mock_conn.execute.call_args_list[1][0][0]
+            assert BOOTSTRAP_SUCCESS_SENTINEL_PATH in bootstrap_cmd
+            assert BOOTSTRAP_SENTINEL_HIT_OUTPUT in bootstrap_cmd
+            assert "systemctl is-active --quiet kubelet" in readiness_cmd
 
     @pytest.mark.asyncio
     async def test_bootstrap_sentinel_short_circuit_logs_skip(self, sshmachine_spec, sshmachine_meta_with_owner):
         mock_conn = AsyncMock()
-        mock_conn.execute.return_value = SSHResult(exit_code=0, stdout=f"{BOOTSTRAP_SENTINEL_HIT_OUTPUT}\n", stderr="")
+        mock_conn.execute.side_effect = [
+            SSHResult(exit_code=0, stdout=f"{BOOTSTRAP_SENTINEL_HIT_OUTPUT}\n", stderr=""),
+            SSHResult(exit_code=0, stdout="active", stderr=""),
+        ]
         mock_conn.upload = AsyncMock()
         mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
         mock_conn.__aexit__ = AsyncMock(return_value=False)
@@ -490,6 +514,55 @@ class TestSSHMachineReconcile:
             assert patch_obj["status"]["bootstrapDiagnostics"]["exitCode"] == 1
             assert patch_obj["status"]["bootstrapDiagnostics"]["stderrExcerpt"] == "error"
             assert "Bootstrap join phase failed" in patch_obj["status"]["failureMessage"]
+
+    @pytest.mark.asyncio
+    async def test_bootstrap_success_with_kubelet_not_ready_sets_not_ready_status(
+        self,
+        sshmachine_spec,
+        sshmachine_meta_with_owner,
+    ):
+        mock_conn = AsyncMock()
+        mock_conn.execute.side_effect = [
+            SSHResult(exit_code=0, stdout="ok", stderr=""),
+            SSHResult(exit_code=32, stdout="", stderr="inactive"),
+        ]
+        mock_conn.upload = AsyncMock()
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "capi_provider_ssh.controllers.sshmachine._read_bootstrap_data",
+                new_callable=AsyncMock,
+                return_value="#!/bin/bash\nkubeadm join ...",
+            ),
+            patch(
+                "capi_provider_ssh.controllers.sshmachine._read_ssh_key",
+                new_callable=AsyncMock,
+                return_value="fake-key",
+            ),
+            patch(
+                "capi_provider_ssh.controllers.sshmachine.SSHClient.connect",
+                new_callable=AsyncMock,
+                return_value=mock_conn,
+            ),
+        ):
+            patch_obj = kopf.Patch({})
+            with pytest.raises(kopf.TemporaryError, match="Post-bootstrap readiness check failed"):
+                await sshmachine_reconcile(
+                    spec=sshmachine_spec,
+                    status={},
+                    name="m1",
+                    namespace="default",
+                    meta=sshmachine_meta_with_owner,
+                    patch=patch_obj,
+                )
+
+        assert patch_obj["status"]["initialization"]["provisioned"] is False
+        assert patch_obj["status"]["failureReason"] == "KubeletNotReady"
+        assert "Bootstrap completed, but kubelet is not ready" in patch_obj["status"]["failureMessage"]
+        assert patch_obj["status"]["conditions"][0]["reason"] == "KubeletNotReady"
+        assert patch_obj["status"]["conditions"][1]["type"] == "Bootstrapped"
 
     @pytest.mark.asyncio
     async def test_successful_bootstrap_with_cloud_config(self, sshmachine_spec, sshmachine_meta_with_owner):


### PR DESCRIPTION
## Summary
- add a post-bootstrap readiness probe (systemctl is-active --quiet kubelet) before setting Ready=True
- keep SSHMachine not-ready with failureReason=KubeletNotReady when bootstrap succeeded but kubelet is still unhealthy
- preserve actionable diagnostics in failureMessage and expose a Bootstrapped informational condition while waiting
- add unit tests for kubelet readiness pass/fail and adjust bootstrap success tests to validate readiness gating

## Testing
- UV_CACHE_DIR=/tmp/uv-cache uv run ruff check capi_provider_ssh/controllers/sshmachine.py tests/test_sshmachine.py
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest

Closes #145