### PR TITLE
test: expand E2E_SSH_KEY_PATH before key existence checks

### DIFF
--- a/python/tests/e2e/conftest.py
+++ b/python/tests/e2e/conftest.py
@@ -61,7 +61,8 @@ def ssh_private_key():
     Uses E2E_SSH_KEY_PATH env var (default: ~/.ssh/id_ed25519).
     Skips if the key file doesn't exist.
     """
-    key_path = os.environ.get("E2E_SSH_KEY_PATH", os.path.expanduser("~/.ssh/id_ed25519"))
+    raw_key_path = os.environ.get("E2E_SSH_KEY_PATH", "~/.ssh/id_ed25519")
+    key_path = os.path.expanduser(os.path.expandvars(raw_key_path))
     if not os.path.exists(key_path):
         pytest.skip(f"SSH private key not found: {key_path}")
     with open(key_path) as f:

--- a/python/tests/test_e2e_ssh_private_key_fixture.py
+++ b/python/tests/test_e2e_ssh_private_key_fixture.py
@@ -1,0 +1,31 @@
+"""Regression tests for E2E SSH key fixture path handling."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.e2e import conftest as e2e_conftest
+
+
+def test_ssh_private_key_expands_tilde_env_path(monkeypatch, tmp_path):
+    home_dir = tmp_path / "home"
+    key_file = home_dir / ".ssh" / "e2e_key"
+    key_file.parent.mkdir(parents=True)
+    key_file.write_text("fake-private-key", encoding="utf-8")
+
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.setenv("E2E_SSH_KEY_PATH", "~/.ssh/e2e_key")
+
+    assert e2e_conftest.ssh_private_key.__wrapped__() == "fake-private-key"
+
+
+def test_ssh_private_key_skip_reports_expanded_path(monkeypatch, tmp_path):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.setenv("E2E_SSH_KEY_PATH", "~/.ssh/missing_key")
+
+    with pytest.raises(pytest.skip.Exception) as exc:
+        e2e_conftest.ssh_private_key.__wrapped__()
+
+    assert str(home_dir / ".ssh" / "missing_key") in str(exc.value)


### PR DESCRIPTION
## Summary
- expand `E2E_SSH_KEY_PATH` with `os.path.expanduser` and `os.path.expandvars` before `os.path.exists`
- preserve skip behavior, but ensure CI path `~/.ssh/e2e_key` resolves correctly
- add regression tests to prevent silent all-skipped E2E runs

## Validation
- `PYTHONPATH=. /Users/administrator/Documents/Programming/Insight/capi-provider-ssh/python/.venv/bin/ruff check tests/e2e/conftest.py tests/test_e2e_ssh_private_key_fixture.py`
- `PYTHONPATH=. /Users/administrator/Documents/Programming/Insight/capi-provider-ssh/python/.venv/bin/ruff format --check tests/e2e/conftest.py tests/test_e2e_ssh_private_key_fixture.py`
- `PYTHONPATH=. /Users/administrator/Documents/Programming/Insight/capi-provider-ssh/python/.venv/bin/pytest -q tests/test_e2e_ssh_private_key_fixture.py`

## Context
Addresses reviewer feedback from release PR #182.
