### PR TITLE
test: broaden unreachable-host assertion for E2E SSH

### DIFF
--- a/python/tests/e2e/test_ssh_connectivity.py
+++ b/python/tests/e2e/test_ssh_connectivity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncssh
 import pytest
 
 from capi_provider_ssh.ssh import SSHClient
@@ -37,8 +38,8 @@ class TestSSHConnectivity:
         assert result.success is False
 
     async def test_connect_timeout_unreachable(self, ssh_private_key):
-        """Connecting to an unreachable address with a short timeout raises TimeoutError."""
-        with pytest.raises(TimeoutError):
+        """Connecting to an unreachable address fails across route-dependent error types."""
+        with pytest.raises((TimeoutError, asyncssh.Error, OSError)):
             await SSHClient.connect(
                 address="192.0.2.1",  # TEST-NET-1 (RFC 5737), guaranteed unreachable
                 port=22,


### PR DESCRIPTION
## Summary
- update `tests/e2e/test_ssh_connectivity.py` to accept route-dependent unreachable-host failures
- allow `TimeoutError`, `asyncssh.Error`, or `OSError` when connecting to `192.0.2.1`

## Why
On some runners the TEST-NET-1 route fails immediately instead of timing out, which can make the nightly E2E suite fail for topology reasons rather than SSH regressions.

## Validation
- `PYTHONPATH=. /Users/administrator/Documents/Programming/Insight/capi-provider-ssh/python/.venv/bin/ruff check tests/e2e/test_ssh_connectivity.py`
- `PYTHONPATH=. /Users/administrator/Documents/Programming/Insight/capi-provider-ssh/python/.venv/bin/ruff format --check tests/e2e/test_ssh_connectivity.py`
- `PYTHONPATH=. /Users/administrator/Documents/Programming/Insight/capi-provider-ssh/python/.venv/bin/pytest -q tests/e2e/test_ssh_connectivity.py -k test_connect_timeout_unreachable`

## Context
Addresses open reviewer comment on release PR #182.
