### PR TITLE
fix: persist stale SSHHost claim clearing + document Lima reprovision

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -58,6 +58,35 @@ preKubeadmCommands:
   - iptables -F && iptables -t nat -F && iptables -t mangle -F
 ```
 
+## How should I re-provision Lima-backed nodes?
+
+Always drive lifecycle from CAPI core objects:
+
+```bash
+kubectl -n <namespace> delete machine <machine-name>
+```
+
+Do **not** delete `SSHMachine` directly for reprovision. Deleting the `Machine`
+lets CAPI orchestrate infrastructure deletion, and the provider can release
+`SSHHost` claims and run node cleanup (`kubeadm reset`).
+
+If you use Lima-hosted VMs, choose one of these host-side reset paths before
+re-bootstrap:
+
+1. Reset Kubernetes state in-place (keep VMs):
+   ```bash
+   limactl shell <vm-name> -- sudo kubeadm reset -f
+   limactl shell <vm-name> -- sudo rm -rf /etc/kubernetes /var/lib/kubelet
+   ```
+2. Recreate VMs for a full clean slate:
+   ```bash
+   limactl delete <vm-name>
+   limactl start <vm-config-or-instance>
+   ```
+
+`limactl` usage and VM names are user/environment-specific and are outside the
+provider API contract.
+
 ## Is SSHHost health probing functional?
 
 **Yes.** The SSHHost controller runs a timer-based probe on each SSHHost:

--- a/python/capi_provider_ssh/controllers/sshmachine.py
+++ b/python/capi_provider_ssh/controllers/sshmachine.py
@@ -982,10 +982,15 @@ def _patch_host_consumer(
     in_use: bool,
     resource_version: str | None,
 ) -> bool:
-    """Patch SSHHost consumerRef with optimistic concurrency (resourceVersion)."""
+    """Patch SSHHost consumerRef with optimistic concurrency (resourceVersion).
+
+    Clearing with `{}` is a no-op under JSON merge patch semantics for nested
+    objects. Use `null` to remove spec.consumerRef keys definitively.
+    """
+    consumer_ref_patch: dict | None = consumer_ref if consumer_ref else None
     body: dict = {
         "spec": {
-            "consumerRef": consumer_ref,
+            "consumerRef": consumer_ref_patch,
         },
         "status": {
             "inUse": in_use,

--- a/python/tests/test_sshmachine.py
+++ b/python/tests/test_sshmachine.py
@@ -1161,7 +1161,7 @@ class TestSSHMachineDelete:
             call_kwargs = mock_api.patch_namespaced_custom_object.call_args
             assert call_kwargs[1]["name"] == "host-2"
             body = call_kwargs[1]["body"]
-            assert body["spec"]["consumerRef"] == {}
+            assert body["spec"]["consumerRef"] is None
             assert body["status"]["inUse"] is False
 
     @pytest.mark.asyncio
@@ -1350,7 +1350,7 @@ class TestChooseHost:
             assert mock_api.patch_namespaced_custom_object.call_count == 2
             first_call = mock_api.patch_namespaced_custom_object.call_args_list[0][1]["body"]
             second_call = mock_api.patch_namespaced_custom_object.call_args_list[1][1]["body"]
-            assert first_call["spec"]["consumerRef"] == {}
+            assert first_call["spec"]["consumerRef"] is None
             assert second_call["spec"]["consumerRef"]["name"] == "m1"
 
     @pytest.mark.asyncio
@@ -1399,7 +1399,7 @@ class TestReleaseHost:
             await _release_host(spec, "m1", "default")
             mock_api.patch_namespaced_custom_object.assert_called_once()
             body = mock_api.patch_namespaced_custom_object.call_args[1]["body"]
-            assert body["spec"]["consumerRef"] == {}
+            assert body["spec"]["consumerRef"] is None
             assert body["status"]["inUse"] is False
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- fix stale SSHHost claim clearing so reclaim/release persists (`spec.consumerRef` now clears via `null` instead of `{}` in merge patch)
- keep `status.inUse` updates in the same host patch flow
- add FAQ guidance for Lima-backed reprovision workflows (in-place reset vs full recreate)
- document that VM lifecycle tooling/naming is environment-specific and outside provider API scope

## Why
In field reports, controller logs showed stale-claim reclaim attempts, but `SSHHost.spec.consumerRef` remained set to deleted SSHMachines. This blocked host reuse and caused reprovision loops.

## Validation
- `PYTHONPATH=. /Users/administrator/Documents/Programming/Insight/capi-provider-ssh/python/.venv/bin/ruff check capi_provider_ssh/controllers/sshmachine.py tests/test_sshmachine.py`
- `PYTHONPATH=. /Users/administrator/Documents/Programming/Insight/capi-provider-ssh/python/.venv/bin/ruff format --check capi_provider_ssh/controllers/sshmachine.py tests/test_sshmachine.py`
- `PYTHONPATH=. /Users/administrator/Documents/Programming/Insight/capi-provider-ssh/python/.venv/bin/pytest -q tests/test_sshmachine.py -k "reclaims_orphaned_host or release_clears_consumer_ref or delete_releases_host"`

## Related
- Refs #188
