### PR TITLE
fix(sshmachine): backfill providerID/ready for already-provisioned machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **sshmachine:** Classify bootstrap failure phases
 - **sshmachine:** Gate ready on kubelet post-bootstrap checks
 - Persist stale SSHHost claim clearing and document Lima reprovision
+- **sshmachine:** Backfill status.ready and providerID on already-provisioned machines
 
 ### Documentation
 

--- a/python/capi_provider_ssh/controllers/sshmachine.py
+++ b/python/capi_provider_ssh/controllers/sshmachine.py
@@ -724,6 +724,54 @@ def _is_already_provisioned(status: dict, expected_provider_id: str) -> bool:
     return bool(init.get("provisioned"))
 
 
+def _has_ready_true_condition(status: dict) -> bool:
+    """Return True when status.conditions includes Ready=True."""
+    for condition in status.get("conditions", []):
+        if condition.get("type") != "Ready":
+            continue
+        if str(condition.get("status", "")).lower() == "true":
+            return True
+    return False
+
+
+def _backfill_provisioned_fields(spec: dict, status: dict, patch, provider_id: str, address: str) -> bool:
+    """Patch missing providerID/readiness fields on already-provisioned SSHMachines."""
+    changed = False
+
+    if spec.get("providerID") != provider_id:
+        patch.spec["providerID"] = provider_id
+        changed = True
+
+    if status.get("ready") is not True:
+        patch.status["ready"] = True
+        changed = True
+
+    init = status.get("initialization", {})
+    if not bool(init.get("provisioned")):
+        patch.status["initialization"] = {"provisioned": True}
+        changed = True
+
+    if not _has_ready_true_condition(status):
+        patch.status["conditions"] = [
+            _ready_condition(f"Machine {address} already provisioned with providerID {provider_id}"),
+        ]
+        changed = True
+
+    if status.get("failureReason") is not None:
+        patch.status["failureReason"] = None
+        changed = True
+
+    if status.get("failureMessage") is not None:
+        patch.status["failureMessage"] = None
+        changed = True
+
+    if status.get("bootstrapDiagnostics") is not None:
+        patch.status["bootstrapDiagnostics"] = None
+        changed = True
+
+    return changed
+
+
 def _reconcile_lock_key(namespace: str, name: str) -> str:
     return f"{namespace}/{name}"
 
@@ -1289,7 +1337,16 @@ async def _sshmachine_reconcile_impl(spec, status, name, namespace, meta, patch,
 
     # Idempotency: skip if already provisioned
     if _is_already_provisioned(status, provider_id):
-        logger.info("SSHMachine %s/%s already provisioned (providerID=%s)", namespace, name, provider_id)
+        changed = _backfill_provisioned_fields(spec, status, patch, provider_id, address)
+        if changed:
+            logger.info(
+                "SSHMachine %s/%s already provisioned (providerID=%s), backfilled missing readiness/providerID fields",
+                namespace,
+                name,
+                provider_id,
+            )
+        else:
+            logger.info("SSHMachine %s/%s already provisioned (providerID=%s)", namespace, name, provider_id)
         return
 
     # Keep diagnostics current and prevent stale bootstrap failure details.
@@ -1488,6 +1545,7 @@ async def _sshmachine_reconcile_impl(spec, status, name, namespace, meta, patch,
     # Success
     patch.spec["providerID"] = provider_id
     patch.status["initialization"] = {"provisioned": True}
+    patch.status["ready"] = True
     patch.status["addresses"] = [
         {"type": "InternalIP", "address": address},
     ]

--- a/python/tests/test_sshmachine.py
+++ b/python/tests/test_sshmachine.py
@@ -419,6 +419,7 @@ class TestSSHMachineReconcile:
                 patch=patch_obj,
             )
             assert patch_obj["status"]["initialization"]["provisioned"] is True
+            assert patch_obj["status"]["ready"] is True
             assert patch_obj["spec"]["providerID"] == "ssh://100.64.0.10"
             assert patch_obj["status"]["addresses"][0]["address"] == "100.64.0.10"
             assert patch_obj["status"]["failureReason"] is None
@@ -616,6 +617,7 @@ runcmd:
         assert "cat <<'__CAPI_BOOTSTRAP_FILE_0__' > /etc/kubernetes/bootstrap-marker" in uploaded_script
         assert "kubeadm join 10.0.0.1:6443" in uploaded_script
         assert patch_obj["status"]["initialization"]["provisioned"] is True
+        assert patch_obj["status"]["ready"] is True
 
     @pytest.mark.asyncio
     async def test_timer_recovers_after_owner_reference_appears(self, sshmachine_spec, sshmachine_meta_with_owner):
@@ -664,10 +666,65 @@ runcmd:
             )
 
         assert recover_patch["status"]["initialization"]["provisioned"] is True
+        assert recover_patch["status"]["ready"] is True
         assert recover_patch["spec"]["providerID"] == "ssh://100.64.0.10"
 
     @pytest.mark.asyncio
     async def test_timer_skips_already_provisioned_machine(self, sshmachine_spec, sshmachine_meta_with_owner):
+        spec_with_provider = {**sshmachine_spec, "providerID": "ssh://100.64.0.10"}
+        status = {
+            "initialization": {"provisioned": True},
+            "ready": True,
+            "conditions": [{"type": "Ready", "status": "True"}],
+        }
+        with patch(
+            "capi_provider_ssh.controllers.sshmachine._read_bootstrap_data",
+            new_callable=AsyncMock,
+        ) as read_bootstrap:
+            patch_obj = kopf.Patch({})
+            await sshmachine_reconcile_timer(
+                spec=spec_with_provider,
+                status=status,
+                name="m1",
+                namespace="default",
+                meta=sshmachine_meta_with_owner,
+                patch=patch_obj,
+            )
+        read_bootstrap.assert_not_called()
+        assert patch_obj == {}
+
+    @pytest.mark.asyncio
+    async def test_timer_skips_provisioned_machine_when_ready_false(self, sshmachine_spec, sshmachine_meta_with_owner):
+        status = {
+            "initialization": {"provisioned": True},
+            "ready": False,
+            "conditions": [{"type": "Ready", "status": "False"}],
+        }
+        with patch(
+            "capi_provider_ssh.controllers.sshmachine._read_bootstrap_data",
+            new_callable=AsyncMock,
+        ) as read_bootstrap:
+            patch_obj = kopf.Patch({})
+            await sshmachine_reconcile_timer(
+                spec=sshmachine_spec,
+                status=status,
+                name="m1",
+                namespace="default",
+                meta=sshmachine_meta_with_owner,
+                patch=patch_obj,
+            )
+        read_bootstrap.assert_not_called()
+        assert patch_obj["status"]["ready"] is True
+        assert patch_obj["spec"]["providerID"] == "ssh://100.64.0.10"
+        assert patch_obj["status"]["conditions"][0]["type"] == "Ready"
+        assert patch_obj["status"]["conditions"][0]["status"] == "True"
+
+    @pytest.mark.asyncio
+    async def test_timer_backfills_missing_providerid_and_ready_on_provisioned_machine(
+        self,
+        sshmachine_spec,
+        sshmachine_meta_with_owner,
+    ):
         status = {
             "initialization": {"provisioned": True},
             "conditions": [{"type": "Ready", "status": "True"}],
@@ -686,27 +743,8 @@ runcmd:
                 patch=patch_obj,
             )
         read_bootstrap.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_timer_skips_provisioned_machine_when_ready_false(self, sshmachine_spec, sshmachine_meta_with_owner):
-        status = {
-            "initialization": {"provisioned": True},
-            "conditions": [{"type": "Ready", "status": "False"}],
-        }
-        with patch(
-            "capi_provider_ssh.controllers.sshmachine._read_bootstrap_data",
-            new_callable=AsyncMock,
-        ) as read_bootstrap:
-            patch_obj = kopf.Patch({})
-            await sshmachine_reconcile_timer(
-                spec=sshmachine_spec,
-                status=status,
-                name="m1",
-                namespace="default",
-                meta=sshmachine_meta_with_owner,
-                patch=patch_obj,
-            )
-        read_bootstrap.assert_not_called()
+        assert patch_obj["status"]["ready"] is True
+        assert patch_obj["spec"]["providerID"] == "ssh://100.64.0.10"
 
     @pytest.mark.asyncio
     async def test_waiting_reconcile_refreshes_live_state_and_skips_bootstrap(

--- a/shared/crds/sshmachine.yaml
+++ b/shared/crds/sshmachine.yaml
@@ -179,6 +179,9 @@ spec:
                         type: string
                       message:
                         type: string
+                ready:
+                  type: boolean
+                  description: Legacy readiness flag for CAPI machine-controller compatibility (mirrors initialization.provisioned).
                 failureReason:
                   type: string
                 failureMessage:
@@ -219,7 +222,7 @@ spec:
           jsonPath: .spec.providerID
         - name: Ready
           type: boolean
-          jsonPath: .status.initialization.provisioned
+          jsonPath: .status.ready
         - name: Age
           type: date
           jsonPath: .metadata.creationTimestamp


### PR DESCRIPTION
## Summary
- add SSHMachine status.ready to CRD schema as a compatibility readiness field
- set status.ready=true on successful SSHMachine provisioning
- in the already-provisioned short-circuit path, backfill missing fields without rerunning bootstrap:
  - spec.providerID
  - status.ready
  - Ready=True condition if absent
  - clear stale failure fields/diagnostics
- keep idempotent behavior and avoid status churn when fields are already correct

## Why
Fixes a v0.3.17 behavior where SSHMachine can report provisioned/ready conditions but Machine.spec.providerID remains null because readiness/providerID compatibility fields are not consistently surfaced.

## Testing
- UV_CACHE_DIR=/tmp/uv-cache uv run ruff check capi_provider_ssh/controllers/sshmachine.py tests/test_sshmachine.py
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_sshmachine.py
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest

Closes #192