### PR TITLE
fix(sshmachine): keep ready in every provisioned reconcile patch

### DIFF
--- a/python/capi_provider_ssh/controllers/sshmachine.py
+++ b/python/capi_provider_ssh/controllers/sshmachine.py
@@ -43,7 +43,6 @@ SSHMACHINE_DISTRIBUTED_LOCK_RETRY_DELAY_SECONDS = int(
     os.environ.get("SSHMACHINE_DISTRIBUTED_LOCK_RETRY_DELAY_SECONDS", "5"),
 )
 SSHMACHINE_DISTRIBUTED_LOCK_ANNOTATION = "infrastructure.cluster.x-k8s.io/reconcile-lock"
-SSHMACHINE_READY_OWNERSHIP_ANNOTATION = f"{API_GROUP}/status-ready-owned"
 BOOTSTRAP_SUCCESS_SENTINEL_PATH = "/run/cluster-api/bootstrap-success.complete"
 BOOTSTRAP_SENTINEL_HIT_OUTPUT = "__CAPI_PROVIDER_SSH_BOOTSTRAP_SENTINEL_HIT__"
 KUBELET_READY_SENTINEL_OUTPUT = "__CAPI_PROVIDER_SSH_KUBELET_READY__"
@@ -743,8 +742,9 @@ def _backfill_provisioned_fields(spec: dict, status: dict, patch, provider_id: s
         patch.spec["providerID"] = provider_id
         changed = True
 
+    # Always include ready=True in the handler patch so kopf keeps the field in owned status.
+    patch.status["ready"] = True
     if status.get("ready") is not True:
-        patch.status["ready"] = True
         changed = True
 
     init = status.get("initialization", {})
@@ -771,18 +771,6 @@ def _backfill_provisioned_fields(spec: dict, status: dict, patch, provider_id: s
         changed = True
 
     return changed
-
-
-def _claim_ready_field_ownership(meta: dict, patch) -> bool:
-    """Write status.ready once via kopf patch to keep ownership stable across upgrades."""
-    annotations = meta.get("annotations") or {}
-    if annotations.get(SSHMACHINE_READY_OWNERSHIP_ANNOTATION) == "true":
-        return False
-
-    patch.status["ready"] = True
-    patch.metadata.setdefault("annotations", {})
-    patch.metadata["annotations"][SSHMACHINE_READY_OWNERSHIP_ANNOTATION] = "true"
-    return True
 
 
 def _reconcile_lock_key(namespace: str, name: str) -> str:
@@ -1351,7 +1339,6 @@ async def _sshmachine_reconcile_impl(spec, status, name, namespace, meta, patch,
     # Idempotency: skip if already provisioned
     if _is_already_provisioned(status, provider_id):
         changed = _backfill_provisioned_fields(spec, status, patch, provider_id, address)
-        changed = _claim_ready_field_ownership(meta, patch) or changed
         if changed:
             logger.info(
                 "SSHMachine %s/%s already provisioned (providerID=%s), ensured readiness/providerID persistence",

--- a/python/tests/test_sshmachine.py
+++ b/python/tests/test_sshmachine.py
@@ -11,7 +11,6 @@ from capi_provider_ssh.controllers.sshmachine import (
     _RECONCILE_LOCK_HOLDER,
     BOOTSTRAP_SENTINEL_HIT_OUTPUT,
     BOOTSTRAP_SUCCESS_SENTINEL_PATH,
-    SSHMACHINE_READY_OWNERSHIP_ANNOTATION,
     _acquire_distributed_reconcile_lock,
     _bootstrap_execution_command,
     _build_reconcile_lock_holder,
@@ -314,7 +313,7 @@ class TestSSHMachineReconcile:
             meta=sshmachine_meta_with_owner,
             patch=patch_obj,
         )
-        # Should not modify status (idempotent)
+        assert patch_obj["status"]["ready"] is True
         assert "initialization" not in patch_obj.get("status", {})
 
     @pytest.mark.asyncio
@@ -337,6 +336,7 @@ class TestSSHMachineReconcile:
                 patch=patch_obj,
             )
         read_bootstrap.assert_not_called()
+        assert patch_obj["status"]["ready"] is True
         assert "initialization" not in patch_obj.get("status", {})
 
     @pytest.mark.asyncio
@@ -693,10 +693,10 @@ runcmd:
             )
         read_bootstrap.assert_not_called()
         assert patch_obj["status"]["ready"] is True
-        assert patch_obj["metadata"]["annotations"][SSHMACHINE_READY_OWNERSHIP_ANNOTATION] == "true"
+        assert "metadata" not in patch_obj
 
     @pytest.mark.asyncio
-    async def test_timer_skips_already_provisioned_machine_when_ready_ownership_is_marked(
+    async def test_timer_keeps_ready_field_in_patch_even_when_annotation_exists(
         self,
         sshmachine_spec,
         sshmachine_meta_with_owner,
@@ -709,7 +709,7 @@ runcmd:
         }
         meta_with_ready_ownership = {
             **sshmachine_meta_with_owner,
-            "annotations": {SSHMACHINE_READY_OWNERSHIP_ANNOTATION: "true"},
+            "annotations": {"infrastructure.alpininsight.ai/status-ready-owned": "true"},
         }
         with patch(
             "capi_provider_ssh.controllers.sshmachine._read_bootstrap_data",
@@ -725,7 +725,8 @@ runcmd:
                 patch=patch_obj,
             )
         read_bootstrap.assert_not_called()
-        assert patch_obj == {}
+        assert patch_obj["status"]["ready"] is True
+        assert "metadata" not in patch_obj
 
     @pytest.mark.asyncio
     async def test_timer_skips_provisioned_machine_when_ready_false(self, sshmachine_spec, sshmachine_meta_with_owner):


### PR DESCRIPTION
## Summary
- remove annotation-based ready ownership workaround from #196 follow-up
- always include `patch.status["ready"] = True` for already-provisioned SSHMachines
- keep idempotent change detection while ensuring kopf patch payload always carries `status.ready`
- update reconcile/timer tests to assert ready is kept in patch payload for provisioned machines

## Validation
- `python3 -m compileall python/capi_provider_ssh/controllers/sshmachine.py python/tests/test_sshmachine.py`

Fixes #196
