### PR TITLE
Fix #204: expand lifecycle condition set for SSHCluster/SSHMachine

### DIFF
--- a/python/capi_provider_ssh/controllers/sshcluster.py
+++ b/python/capi_provider_ssh/controllers/sshcluster.py
@@ -15,6 +15,8 @@ from capi_provider_ssh import API_GROUP, API_VERSION
 logger = logging.getLogger(__name__)
 
 FINALIZER = f"{API_GROUP}/sshcluster-controller"
+CLUSTER_INFRASTRUCTURE_READY_CONDITION = "InfrastructureReady"
+CLUSTER_ENDPOINT_READY_CONDITION = "ControlPlaneEndpointReady"
 
 
 def _now_iso() -> str:
@@ -31,24 +33,51 @@ def _has_capi_cluster_owner(owner_references: list[dict] | None) -> bool:
     )
 
 
-def _ready_condition(message: str) -> dict:
+def _condition(condition_type: str, status: str, reason: str, message: str) -> dict:
     return {
-        "type": "Ready",
-        "status": "True",
-        "lastTransitionTime": _now_iso(),
-        "reason": "Provisioned",
-        "message": message,
-    }
-
-
-def _not_ready_condition(reason: str, message: str) -> dict:
-    return {
-        "type": "Ready",
-        "status": "False",
+        "type": condition_type,
+        "status": status,
         "lastTransitionTime": _now_iso(),
         "reason": reason,
         "message": message,
     }
+
+
+def _ready_condition(message: str) -> dict:
+    return _condition("Ready", "True", "Provisioned", message)
+
+
+def _not_ready_condition(reason: str, message: str) -> dict:
+    return _condition("Ready", "False", reason, message)
+
+
+def _cluster_lifecycle_conditions(
+    *,
+    ready: bool,
+    ready_reason: str,
+    ready_message: str,
+    infrastructure_ready: bool,
+    infrastructure_reason: str,
+    infrastructure_message: str,
+    endpoint_ready: bool,
+    endpoint_reason: str,
+    endpoint_message: str,
+) -> list[dict]:
+    return [
+        _condition("Ready", "True" if ready else "False", ready_reason, ready_message),
+        _condition(
+            CLUSTER_INFRASTRUCTURE_READY_CONDITION,
+            "True" if infrastructure_ready else "False",
+            infrastructure_reason,
+            infrastructure_message,
+        ),
+        _condition(
+            CLUSTER_ENDPOINT_READY_CONDITION,
+            "True" if endpoint_ready else "False",
+            endpoint_reason,
+            endpoint_message,
+        ),
+    ]
 
 
 def _reconcile(spec: dict, name: str, namespace: str, meta: dict, patch: kopf.Patch) -> None:
@@ -60,11 +89,21 @@ def _reconcile(spec: dict, name: str, namespace: str, meta: dict, patch: kopf.Pa
     owner_refs = meta.get("ownerReferences")
     if not _has_capi_cluster_owner(owner_refs):
         logger.warning("SSHCluster %s/%s has no CAPI Cluster owner, waiting", namespace, name)
+        message = "No CAPI Cluster ownerReference found"
+        reason = "WaitingForClusterOwner"
         patch.status["initialization"] = {"provisioned": False}
         patch.status["ready"] = False
-        patch.status["conditions"] = [
-            _not_ready_condition("WaitingForClusterOwner", "No CAPI Cluster ownerReference found"),
-        ]
+        patch.status["conditions"] = _cluster_lifecycle_conditions(
+            ready=False,
+            ready_reason=reason,
+            ready_message=message,
+            infrastructure_ready=False,
+            infrastructure_reason=reason,
+            infrastructure_message=message,
+            endpoint_ready=False,
+            endpoint_reason=reason,
+            endpoint_message="Control plane endpoint cannot be evaluated before owner is available",
+        )
         return
 
     endpoint = spec.get("controlPlaneEndpoint", {})
@@ -72,18 +111,37 @@ def _reconcile(spec: dict, name: str, namespace: str, meta: dict, patch: kopf.Pa
     port = endpoint.get("port", 0)
 
     if not host or not port:
+        reason = "InvalidEndpoint"
+        message = f"Invalid controlPlaneEndpoint: {host}:{port}"
         patch.status["initialization"] = {"provisioned": False}
         patch.status["ready"] = False
-        patch.status["conditions"] = [
-            _not_ready_condition("InvalidEndpoint", f"Invalid controlPlaneEndpoint: {host}:{port}"),
-        ]
+        patch.status["conditions"] = _cluster_lifecycle_conditions(
+            ready=False,
+            ready_reason=reason,
+            ready_message=message,
+            infrastructure_ready=False,
+            infrastructure_reason=reason,
+            infrastructure_message=message,
+            endpoint_ready=False,
+            endpoint_reason=reason,
+            endpoint_message=message,
+        )
         return
 
+    message = f"Control plane endpoint {host}:{port} registered"
     patch.status["initialization"] = {"provisioned": True}
     patch.status["ready"] = True
-    patch.status["conditions"] = [
-        _ready_condition(f"Control plane endpoint {host}:{port} registered"),
-    ]
+    patch.status["conditions"] = _cluster_lifecycle_conditions(
+        ready=True,
+        ready_reason="Provisioned",
+        ready_message=message,
+        infrastructure_ready=True,
+        infrastructure_reason="Provisioned",
+        infrastructure_message=message,
+        endpoint_ready=True,
+        endpoint_reason="EndpointConfigured",
+        endpoint_message=message,
+    )
     logger.info("SSHCluster %s/%s reconciled: endpoint=%s:%d", namespace, name, host, port)
 
 
@@ -102,6 +160,20 @@ async def sshcluster_update(spec, name, namespace, meta, patch, **_kwargs):
 
 
 @kopf.on.delete(API_GROUP, API_VERSION, "sshclusters")
-async def sshcluster_delete(name, namespace, **_kwargs):
+async def sshcluster_delete(name, namespace, patch=None, **_kwargs):
     """Handle SSHCluster deletion -- no-op cleanup."""
+    if patch is not None:
+        patch.status["initialization"] = {"provisioned": False}
+        patch.status["ready"] = False
+        patch.status["conditions"] = _cluster_lifecycle_conditions(
+            ready=False,
+            ready_reason="Deleting",
+            ready_message="Cluster infrastructure is deleting",
+            infrastructure_ready=False,
+            infrastructure_reason="Deleting",
+            infrastructure_message="Cluster infrastructure is deleting",
+            endpoint_ready=False,
+            endpoint_reason="Deleting",
+            endpoint_message="Control plane endpoint is being removed",
+        )
     logger.info("SSHCluster %s/%s deleted (no-op cleanup)", namespace, name)

--- a/python/capi_provider_ssh/controllers/sshmachine.py
+++ b/python/capi_provider_ssh/controllers/sshmachine.py
@@ -69,40 +69,67 @@ def _build_reconcile_lock_holder() -> str:
 
 
 _RECONCILE_LOCK_HOLDER = _build_reconcile_lock_holder()
+MACHINE_INFRASTRUCTURE_READY_CONDITION = "InfrastructureReady"
+MACHINE_BOOTSTRAP_EXEC_SUCCEEDED_CONDITION = "BootstrapExecSucceeded"
 
 
 def _now_iso() -> str:
     return datetime.datetime.now(datetime.UTC).isoformat()
 
 
-def _ready_condition(message: str) -> dict:
+def _condition(condition_type: str, status: str, reason: str, message: str) -> dict:
     return {
-        "type": "Ready",
-        "status": "True",
+        "type": condition_type,
+        "status": status,
         "lastTransitionTime": _now_iso(),
-        "reason": "Provisioned",
+        "reason": reason,
         "message": message,
     }
+
+
+def _ready_condition(message: str) -> dict:
+    return _condition("Ready", "True", "Provisioned", message)
 
 
 def _not_ready_condition(reason: str, message: str) -> dict:
-    return {
-        "type": "Ready",
-        "status": "False",
-        "lastTransitionTime": _now_iso(),
-        "reason": reason,
-        "message": message,
-    }
+    return _condition("Ready", "False", reason, message)
 
 
 def _info_condition(condition_type: str, reason: str, message: str) -> dict:
-    return {
-        "type": condition_type,
-        "status": "True",
-        "lastTransitionTime": _now_iso(),
-        "reason": reason,
-        "message": message,
-    }
+    return _condition(condition_type, "True", reason, message)
+
+
+def _machine_lifecycle_conditions(
+    *,
+    ready: bool,
+    ready_reason: str,
+    ready_message: str,
+    infrastructure_ready: bool,
+    infrastructure_reason: str,
+    infrastructure_message: str,
+    bootstrap_succeeded: bool,
+    bootstrap_reason: str,
+    bootstrap_message: str,
+    extras: list[dict] | None = None,
+) -> list[dict]:
+    conditions = [
+        _condition("Ready", "True" if ready else "False", ready_reason, ready_message),
+        _condition(
+            MACHINE_INFRASTRUCTURE_READY_CONDITION,
+            "True" if infrastructure_ready else "False",
+            infrastructure_reason,
+            infrastructure_message,
+        ),
+        _condition(
+            MACHINE_BOOTSTRAP_EXEC_SUCCEEDED_CONDITION,
+            "True" if bootstrap_succeeded else "False",
+            bootstrap_reason,
+            bootstrap_message,
+        ),
+    ]
+    if extras:
+        conditions.extend(extras)
+    return conditions
 
 
 def _has_machine_owner(owner_references: list[dict] | None) -> bool:
@@ -724,12 +751,12 @@ def _is_already_provisioned(status: dict, expected_provider_id: str) -> bool:
     return bool(init.get("provisioned"))
 
 
-def _has_ready_true_condition(status: dict) -> bool:
-    """Return True when status.conditions includes Ready=True."""
+def _has_condition_status(status: dict, condition_type: str, condition_status: str) -> bool:
+    """Return True when status.conditions includes a matching type/status pair."""
     for condition in status.get("conditions", []):
-        if condition.get("type") != "Ready":
+        if condition.get("type") != condition_type:
             continue
-        if str(condition.get("status", "")).lower() == "true":
+        if str(condition.get("status", "")).lower() == condition_status.lower():
             return True
     return False
 
@@ -752,10 +779,23 @@ def _backfill_provisioned_fields(spec: dict, status: dict, patch, provider_id: s
         patch.status["initialization"] = {"provisioned": True}
         changed = True
 
-    if not _has_ready_true_condition(status):
-        patch.status["conditions"] = [
-            _ready_condition(f"Machine {address} already provisioned with providerID {provider_id}"),
-        ]
+    if (
+        not _has_condition_status(status, "Ready", "True")
+        or not _has_condition_status(status, MACHINE_INFRASTRUCTURE_READY_CONDITION, "True")
+        or not _has_condition_status(status, MACHINE_BOOTSTRAP_EXEC_SUCCEEDED_CONDITION, "True")
+    ):
+        ready_message = f"Machine {address} already provisioned with providerID {provider_id}"
+        patch.status["conditions"] = _machine_lifecycle_conditions(
+            ready=True,
+            ready_reason="Provisioned",
+            ready_message=ready_message,
+            infrastructure_ready=True,
+            infrastructure_reason="Provisioned",
+            infrastructure_message=ready_message,
+            bootstrap_succeeded=True,
+            bootstrap_reason="BootstrapCompleted",
+            bootstrap_message="Bootstrap execution has completed for this machine",
+        )
         changed = True
 
     if status.get("failureReason") is not None:
@@ -1115,12 +1155,24 @@ async def _choose_host(spec: dict, name: str, namespace: str, patch) -> bool:
         # Direct mode: address is required when hostSelector is not used.
         if spec.get("address"):
             return True
+        message = "Either address or hostSelector must be provided"
+        reason = "InvalidConfiguration"
         patch.status["failureReason"] = "InvalidConfiguration"
-        patch.status["failureMessage"] = "Either address or hostSelector must be provided"
-        patch.status["conditions"] = [
-            _not_ready_condition("InvalidConfiguration", "Either address or hostSelector must be provided"),
-        ]
-        raise kopf.PermanentError("Either address or hostSelector must be provided")
+        patch.status["failureMessage"] = message
+        patch.status["ready"] = False
+        patch.status["initialization"] = {"provisioned": False}
+        patch.status["conditions"] = _machine_lifecycle_conditions(
+            ready=False,
+            ready_reason=reason,
+            ready_message=message,
+            infrastructure_ready=False,
+            infrastructure_reason=reason,
+            infrastructure_message=message,
+            bootstrap_succeeded=False,
+            bootstrap_reason="BootstrapNotStarted",
+            bootstrap_message="Bootstrap has not started because machine configuration is invalid",
+        )
+        raise kopf.PermanentError(message)
 
     match_labels = host_selector.get("matchLabels", {})
     if not match_labels:
@@ -1235,10 +1287,21 @@ async def _choose_host(spec: dict, name: str, namespace: str, patch) -> bool:
         return True
 
     # No available host found
+    message = f"No unclaimed SSHHost matching {match_labels}"
+    reason = "HostNotAvailable"
     patch.status["initialization"] = {"provisioned": False}
-    patch.status["conditions"] = [
-        _not_ready_condition("HostNotAvailable", f"No unclaimed SSHHost matching {match_labels}"),
-    ]
+    patch.status["ready"] = False
+    patch.status["conditions"] = _machine_lifecycle_conditions(
+        ready=False,
+        ready_reason=reason,
+        ready_message=message,
+        infrastructure_ready=False,
+        infrastructure_reason=reason,
+        infrastructure_message=message,
+        bootstrap_succeeded=False,
+        bootstrap_reason="BootstrapNotStarted",
+        bootstrap_message="Bootstrap has not started because no SSHHost is available",
+    )
     raise kopf.TemporaryError(f"No available SSHHost matching {match_labels}", delay=30)
 
 
@@ -1315,10 +1378,21 @@ async def _sshmachine_reconcile_impl(spec, status, name, namespace, meta, patch,
     owner_refs = meta.get("ownerReferences")
     if not _has_machine_owner(owner_refs):
         logger.warning("SSHMachine %s/%s has no CAPI Machine owner, waiting", namespace, name)
+        message = "No CAPI Machine ownerReference found"
+        reason = "WaitingForMachineOwner"
         patch.status["initialization"] = {"provisioned": False}
-        patch.status["conditions"] = [
-            _not_ready_condition("WaitingForMachineOwner", "No CAPI Machine ownerReference found"),
-        ]
+        patch.status["ready"] = False
+        patch.status["conditions"] = _machine_lifecycle_conditions(
+            ready=False,
+            ready_reason=reason,
+            ready_message=message,
+            infrastructure_ready=False,
+            infrastructure_reason=reason,
+            infrastructure_message=message,
+            bootstrap_succeeded=False,
+            bootstrap_reason="BootstrapNotStarted",
+            bootstrap_message="Bootstrap has not started because machine ownerReference is missing",
+        )
         return
 
     machine_ref = _get_machine_owner_ref(owner_refs)
@@ -1357,21 +1431,44 @@ async def _sshmachine_reconcile_impl(spec, status, name, namespace, meta, patch,
     bootstrap_data = await _read_bootstrap_data(namespace, machine_name)
     if not bootstrap_data:
         logger.info("SSHMachine %s/%s waiting for bootstrap data", namespace, name)
+        reason = "WaitingForBootstrapData"
+        message = f"Bootstrap data not yet available for {machine_name}"
         patch.status["initialization"] = {"provisioned": False}
-        patch.status["conditions"] = [
-            _not_ready_condition("WaitingForBootstrapData", f"Bootstrap data not yet available for {machine_name}"),
-        ]
+        patch.status["ready"] = False
+        patch.status["conditions"] = _machine_lifecycle_conditions(
+            ready=False,
+            ready_reason=reason,
+            ready_message=message,
+            infrastructure_ready=False,
+            infrastructure_reason=reason,
+            infrastructure_message=message,
+            bootstrap_succeeded=False,
+            bootstrap_reason=reason,
+            bootstrap_message=message,
+        )
         raise kopf.TemporaryError("Bootstrap data not ready", delay=15)
 
     # Optional external-etcd wiring and cert distribution configuration.
     try:
         external_etcd = _normalize_external_etcd(spec)
     except kopf.PermanentError as e:
-        patch.status["failureReason"] = "ExternalEtcdConfigurationError"
-        patch.status["failureMessage"] = str(e)
-        patch.status["conditions"] = [
-            _not_ready_condition("ExternalEtcdConfigurationError", str(e)),
-        ]
+        reason = "ExternalEtcdConfigurationError"
+        message = str(e)
+        patch.status["failureReason"] = reason
+        patch.status["failureMessage"] = message
+        patch.status["ready"] = False
+        patch.status["initialization"] = {"provisioned": False}
+        patch.status["conditions"] = _machine_lifecycle_conditions(
+            ready=False,
+            ready_reason=reason,
+            ready_message=message,
+            infrastructure_ready=False,
+            infrastructure_reason=reason,
+            infrastructure_message=message,
+            bootstrap_succeeded=False,
+            bootstrap_reason="BootstrapNotStarted",
+            bootstrap_message="Bootstrap has not started due to external etcd configuration error",
+        )
         raise
 
     if external_etcd:
@@ -1380,21 +1477,45 @@ async def _sshmachine_reconcile_impl(spec, status, name, namespace, meta, patch,
             if changed:
                 logger.info("SSHMachine %s/%s patched bootstrap data with external etcd wiring", namespace, name)
         except kopf.PermanentError as e:
-            patch.status["failureReason"] = "ExternalEtcdWiringError"
-            patch.status["failureMessage"] = str(e)
-            patch.status["conditions"] = [
-                _not_ready_condition("ExternalEtcdWiringError", str(e)),
-            ]
+            reason = "ExternalEtcdWiringError"
+            message = str(e)
+            patch.status["failureReason"] = reason
+            patch.status["failureMessage"] = message
+            patch.status["ready"] = False
+            patch.status["initialization"] = {"provisioned": False}
+            patch.status["conditions"] = _machine_lifecycle_conditions(
+                ready=False,
+                ready_reason=reason,
+                ready_message=message,
+                infrastructure_ready=False,
+                infrastructure_reason=reason,
+                infrastructure_message=message,
+                bootstrap_succeeded=False,
+                bootstrap_reason="BootstrapNotStarted",
+                bootstrap_message="Bootstrap has not started due to external etcd wiring error",
+            )
             raise
 
     try:
         bootstrap_script, bootstrap_format = _prepare_bootstrap_script(bootstrap_data)
     except kopf.PermanentError as e:
-        patch.status["failureReason"] = "BootstrapFormatError"
-        patch.status["failureMessage"] = str(e)
-        patch.status["conditions"] = [
-            _not_ready_condition("BootstrapFormatError", str(e)),
-        ]
+        reason = "BootstrapFormatError"
+        message = str(e)
+        patch.status["failureReason"] = reason
+        patch.status["failureMessage"] = message
+        patch.status["ready"] = False
+        patch.status["initialization"] = {"provisioned": False}
+        patch.status["conditions"] = _machine_lifecycle_conditions(
+            ready=False,
+            ready_reason=reason,
+            ready_message=message,
+            infrastructure_ready=False,
+            infrastructure_reason=reason,
+            infrastructure_message=message,
+            bootstrap_succeeded=False,
+            bootstrap_reason="BootstrapNotStarted",
+            bootstrap_message="Bootstrap has not started because bootstrap data format is invalid",
+        )
         raise
 
     logger.info("SSHMachine %s/%s bootstrap payload format: %s", namespace, name, bootstrap_format)
@@ -1405,11 +1526,23 @@ async def _sshmachine_reconcile_impl(spec, status, name, namespace, meta, patch,
     secret_key = ssh_key_ref.get("key", "value")
 
     if not secret_name:
-        patch.status["failureReason"] = "InvalidConfiguration"
+        reason = "InvalidConfiguration"
+        message = "Missing sshKeyRef.name"
+        patch.status["failureReason"] = reason
         patch.status["failureMessage"] = "spec.sshKeyRef.name is required"
-        patch.status["conditions"] = [
-            _not_ready_condition("InvalidConfiguration", "Missing sshKeyRef.name"),
-        ]
+        patch.status["ready"] = False
+        patch.status["initialization"] = {"provisioned": False}
+        patch.status["conditions"] = _machine_lifecycle_conditions(
+            ready=False,
+            ready_reason=reason,
+            ready_message=message,
+            infrastructure_ready=False,
+            infrastructure_reason=reason,
+            infrastructure_message=message,
+            bootstrap_succeeded=False,
+            bootstrap_reason="BootstrapNotStarted",
+            bootstrap_message="Bootstrap has not started because SSH key reference is missing",
+        )
         raise kopf.PermanentError("spec.sshKeyRef.name is required")
 
     try:
@@ -1417,11 +1550,23 @@ async def _sshmachine_reconcile_impl(spec, status, name, namespace, meta, patch,
     except kopf.PermanentError:
         raise
     except Exception as e:
-        patch.status["failureReason"] = "SSHKeyReadError"
+        reason = "SSHKeyReadError"
+        message = f"Failed to read SSH key secret: {e}"
+        patch.status["failureReason"] = reason
         patch.status["failureMessage"] = f"Failed to read SSH key: {e}"
-        patch.status["conditions"] = [
-            _not_ready_condition("SSHKeyReadError", f"Failed to read SSH key secret: {e}"),
-        ]
+        patch.status["ready"] = False
+        patch.status["initialization"] = {"provisioned": False}
+        patch.status["conditions"] = _machine_lifecycle_conditions(
+            ready=False,
+            ready_reason=reason,
+            ready_message=message,
+            infrastructure_ready=False,
+            infrastructure_reason=reason,
+            infrastructure_message=message,
+            bootstrap_succeeded=False,
+            bootstrap_reason="BootstrapNotStarted",
+            bootstrap_message="Bootstrap has not started because SSH key retrieval failed",
+        )
         raise kopf.TemporaryError(f"SSH key read failed: {e}", delay=30) from e
 
     # Dry-run mode: validate prerequisites without executing the bootstrap script.
@@ -1430,20 +1575,46 @@ async def _sshmachine_reconcile_impl(spec, status, name, namespace, meta, patch,
             async with await SSHClient.connect(address=address, port=port, user=user, key=ssh_key) as conn:
                 pass  # Connection test only
         except Exception as e:
-            patch.status["failureReason"] = "DryRunSSHFailed"
+            reason = "DryRunSSHFailed"
+            message = f"SSH connectivity check failed: {e}"
+            patch.status["failureReason"] = reason
             patch.status["failureMessage"] = f"Dry-run SSH connectivity check failed: {e}"
-            patch.status["conditions"] = [
-                _not_ready_condition("DryRunSSHFailed", f"SSH connectivity check failed: {e}"),
-            ]
+            patch.status["ready"] = False
+            patch.status["initialization"] = {"provisioned": False}
+            patch.status["conditions"] = _machine_lifecycle_conditions(
+                ready=False,
+                ready_reason=reason,
+                ready_message=message,
+                infrastructure_ready=False,
+                infrastructure_reason=reason,
+                infrastructure_message=message,
+                bootstrap_succeeded=False,
+                bootstrap_reason="DryRunMode",
+                bootstrap_message="Bootstrap execution is skipped in dry-run mode",
+            )
             raise kopf.TemporaryError(f"Dry-run SSH failed: {e}", delay=30) from e
 
-        patch.status["conditions"] = [
-            _info_condition(
-                "DryRunValidated",
-                "PreflightPassed",
-                f"Dry-run passed: SSH to {address}, bootstrap data ready",
-            ),
-        ]
+        dry_run_message = f"Dry-run passed: SSH to {address}, bootstrap data ready"
+        patch.status["ready"] = False
+        patch.status["initialization"] = {"provisioned": False}
+        patch.status["conditions"] = _machine_lifecycle_conditions(
+            ready=False,
+            ready_reason="DryRunMode",
+            ready_message="Dry-run mode does not provision infrastructure",
+            infrastructure_ready=False,
+            infrastructure_reason="DryRunMode",
+            infrastructure_message="Dry-run mode validates prerequisites without provisioning",
+            bootstrap_succeeded=False,
+            bootstrap_reason="DryRunMode",
+            bootstrap_message="Bootstrap execution is skipped in dry-run mode",
+            extras=[
+                _info_condition(
+                    "DryRunValidated",
+                    "PreflightPassed",
+                    dry_run_message,
+                ),
+            ],
+        )
         patch.status["bootstrapDiagnostics"] = None
         patch.status["failureReason"] = None
         patch.status["failureMessage"] = None
@@ -1457,18 +1628,42 @@ async def _sshmachine_reconcile_impl(spec, status, name, namespace, meta, patch,
                 try:
                     await _upload_external_etcd_certs(conn, namespace, external_etcd)
                 except kopf.PermanentError as e:
-                    patch.status["failureReason"] = "ExternalEtcdCertError"
-                    patch.status["failureMessage"] = str(e)
-                    patch.status["conditions"] = [
-                        _not_ready_condition("ExternalEtcdCertError", str(e)),
-                    ]
+                    reason = "ExternalEtcdCertError"
+                    message = str(e)
+                    patch.status["failureReason"] = reason
+                    patch.status["failureMessage"] = message
+                    patch.status["ready"] = False
+                    patch.status["initialization"] = {"provisioned": False}
+                    patch.status["conditions"] = _machine_lifecycle_conditions(
+                        ready=False,
+                        ready_reason=reason,
+                        ready_message=message,
+                        infrastructure_ready=False,
+                        infrastructure_reason=reason,
+                        infrastructure_message=message,
+                        bootstrap_succeeded=False,
+                        bootstrap_reason="BootstrapNotStarted",
+                        bootstrap_message="Bootstrap has not started due to external etcd certificate error",
+                    )
                     raise
                 except kopf.TemporaryError as e:
-                    patch.status["failureReason"] = "ExternalEtcdCertUploadError"
-                    patch.status["failureMessage"] = str(e)
-                    patch.status["conditions"] = [
-                        _not_ready_condition("ExternalEtcdCertUploadError", str(e)),
-                    ]
+                    reason = "ExternalEtcdCertUploadError"
+                    message = str(e)
+                    patch.status["failureReason"] = reason
+                    patch.status["failureMessage"] = message
+                    patch.status["ready"] = False
+                    patch.status["initialization"] = {"provisioned": False}
+                    patch.status["conditions"] = _machine_lifecycle_conditions(
+                        ready=False,
+                        ready_reason=reason,
+                        ready_message=message,
+                        infrastructure_ready=False,
+                        infrastructure_reason=reason,
+                        infrastructure_message=message,
+                        bootstrap_succeeded=False,
+                        bootstrap_reason="BootstrapNotStarted",
+                        bootstrap_message="Bootstrap has not started due to external etcd certificate upload error",
+                    )
                     raise
 
             # Upload bootstrap script
@@ -1489,9 +1684,19 @@ async def _sshmachine_reconcile_impl(spec, status, name, namespace, meta, patch,
                     "exitCode": result.exit_code,
                     "stderrExcerpt": stderr_excerpt,
                 }
-                patch.status["conditions"] = [
-                    _not_ready_condition(failure_reason, failure_message),
-                ]
+                patch.status["ready"] = False
+                patch.status["initialization"] = {"provisioned": False}
+                patch.status["conditions"] = _machine_lifecycle_conditions(
+                    ready=False,
+                    ready_reason=failure_reason,
+                    ready_message=failure_message,
+                    infrastructure_ready=False,
+                    infrastructure_reason=failure_reason,
+                    infrastructure_message=failure_message,
+                    bootstrap_succeeded=False,
+                    bootstrap_reason=failure_reason,
+                    bootstrap_message=failure_message,
+                )
                 raise kopf.TemporaryError(
                     f"Bootstrap failed ({failure_reason}, exit {result.exit_code})",
                     delay=30,
@@ -1511,14 +1716,25 @@ async def _sshmachine_reconcile_impl(spec, status, name, namespace, meta, patch,
                 patch.status["initialization"] = {"provisioned": False}
                 patch.status["failureReason"] = failure_reason
                 patch.status["failureMessage"] = failure_message
-                patch.status["conditions"] = [
-                    _not_ready_condition(failure_reason, failure_message),
-                    _info_condition(
-                        "Bootstrapped",
-                        "BootstrapCompleted",
-                        "Bootstrap script completed; waiting for kubelet readiness checks to pass",
-                    ),
-                ]
+                patch.status["ready"] = False
+                patch.status["conditions"] = _machine_lifecycle_conditions(
+                    ready=False,
+                    ready_reason=failure_reason,
+                    ready_message=failure_message,
+                    infrastructure_ready=False,
+                    infrastructure_reason=failure_reason,
+                    infrastructure_message=failure_message,
+                    bootstrap_succeeded=True,
+                    bootstrap_reason="BootstrapCompleted",
+                    bootstrap_message="Bootstrap script completed; waiting for kubelet readiness checks to pass",
+                    extras=[
+                        _info_condition(
+                            "Bootstrapped",
+                            "BootstrapCompleted",
+                            "Bootstrap script completed; waiting for kubelet readiness checks to pass",
+                        ),
+                    ],
+                )
                 raise kopf.TemporaryError(
                     f"Post-bootstrap readiness check failed ({failure_reason}, exit {readiness_result.exit_code})",
                     delay=30,
@@ -1529,18 +1745,42 @@ async def _sshmachine_reconcile_impl(spec, status, name, namespace, meta, patch,
     except kopf.PermanentError:
         raise
     except TimeoutError as e:
-        patch.status["failureReason"] = "SSHTimeout"
+        reason = "SSHTimeout"
+        message = str(e)
+        patch.status["failureReason"] = reason
         patch.status["failureMessage"] = f"SSH operation timed out: {e}"
-        patch.status["conditions"] = [
-            _not_ready_condition("SSHTimeout", str(e)),
-        ]
+        patch.status["ready"] = False
+        patch.status["initialization"] = {"provisioned": False}
+        patch.status["conditions"] = _machine_lifecycle_conditions(
+            ready=False,
+            ready_reason=reason,
+            ready_message=message,
+            infrastructure_ready=False,
+            infrastructure_reason=reason,
+            infrastructure_message=message,
+            bootstrap_succeeded=False,
+            bootstrap_reason=reason,
+            bootstrap_message="Bootstrap execution was interrupted by SSH timeout",
+        )
         raise kopf.TemporaryError(f"SSH timeout: {e}", delay=30) from e
     except Exception as e:
-        patch.status["failureReason"] = "SSHError"
-        patch.status["failureMessage"] = f"SSH connection failed: {e}"
-        patch.status["conditions"] = [
-            _not_ready_condition("SSHError", f"SSH connection failed: {e}"),
-        ]
+        reason = "SSHError"
+        message = f"SSH connection failed: {e}"
+        patch.status["failureReason"] = reason
+        patch.status["failureMessage"] = message
+        patch.status["ready"] = False
+        patch.status["initialization"] = {"provisioned": False}
+        patch.status["conditions"] = _machine_lifecycle_conditions(
+            ready=False,
+            ready_reason=reason,
+            ready_message=message,
+            infrastructure_ready=False,
+            infrastructure_reason=reason,
+            infrastructure_message=message,
+            bootstrap_succeeded=False,
+            bootstrap_reason=reason,
+            bootstrap_message="Bootstrap execution could not proceed due to SSH error",
+        )
         raise kopf.TemporaryError(f"SSH error: {e}", delay=30) from e
 
     # Success
@@ -1550,9 +1790,18 @@ async def _sshmachine_reconcile_impl(spec, status, name, namespace, meta, patch,
     patch.status["addresses"] = [
         {"type": "InternalIP", "address": address},
     ]
-    patch.status["conditions"] = [
-        _ready_condition(f"Machine {address} provisioned with providerID {provider_id}"),
-    ]
+    success_message = f"Machine {address} provisioned with providerID {provider_id}"
+    patch.status["conditions"] = _machine_lifecycle_conditions(
+        ready=True,
+        ready_reason="Provisioned",
+        ready_message=success_message,
+        infrastructure_ready=True,
+        infrastructure_reason="Provisioned",
+        infrastructure_message=success_message,
+        bootstrap_succeeded=True,
+        bootstrap_reason="BootstrapCompleted",
+        bootstrap_message="Bootstrap execution and readiness checks completed successfully",
+    )
     # Clear any previous failure state
     patch.status["bootstrapDiagnostics"] = None
     patch.status["failureReason"] = None
@@ -1649,9 +1898,24 @@ async def sshmachine_reconcile_timer(spec, status, name, namespace, meta, patch,
 
 
 @kopf.on.delete(API_GROUP, API_VERSION, "sshmachines")
-async def sshmachine_delete(spec, name, namespace, **_kwargs):
+async def sshmachine_delete(spec, name, namespace, patch=None, **_kwargs):
     """Handle SSHMachine deletion -- cleanup via SSH (kubeadm reset) and release host."""
     logger.info("SSHMachine %s/%s deleting", namespace, name)
+    if patch is not None:
+        patch.status["ready"] = False
+        patch.status["initialization"] = {"provisioned": False}
+        patch.status["conditions"] = _machine_lifecycle_conditions(
+            ready=False,
+            ready_reason="Deleting",
+            ready_message="Infrastructure machine is deleting",
+            infrastructure_ready=False,
+            infrastructure_reason="Deleting",
+            infrastructure_message="Infrastructure machine is deleting",
+            bootstrap_succeeded=False,
+            bootstrap_reason="Deleting",
+            bootstrap_message="Bootstrap lifecycle is terminating due to machine deletion",
+        )
+
     lock = _get_reconcile_lock(namespace, name)
     if lock.locked():
         logger.info("SSHMachine %s/%s waiting for in-flight reconcile before delete cleanup", namespace, name)

--- a/python/tests/test_sshcluster.py
+++ b/python/tests/test_sshcluster.py
@@ -8,6 +8,10 @@ from capi_provider_ssh.controllers.sshcluster import (
 )
 
 
+def _conditions_by_type(status: dict) -> dict[str, dict]:
+    return {condition["type"]: condition for condition in status.get("conditions", [])}
+
+
 class TestHasCapiClusterOwner:
     def test_with_cluster_owner(self, sshcluster_meta_with_owner):
         assert _has_capi_cluster_owner(sshcluster_meta_with_owner["ownerReferences"]) is True
@@ -40,15 +44,21 @@ class TestSSHClusterReconcile:
         _reconcile(sshcluster_spec, "test", "default", sshcluster_meta_no_owner, patch)
         assert patch["status"]["initialization"]["provisioned"] is False
         assert patch["status"]["ready"] is False
-        assert patch["status"]["conditions"][0]["reason"] == "WaitingForClusterOwner"
+        conditions = _conditions_by_type(patch["status"])
+        assert conditions["Ready"]["reason"] == "WaitingForClusterOwner"
+        assert conditions["InfrastructureReady"]["status"] == "False"
+        assert conditions["ControlPlaneEndpointReady"]["status"] == "False"
 
     def test_valid_cluster_provisioned(self, sshcluster_spec, sshcluster_meta_with_owner):
         patch = kopf.Patch({})
         _reconcile(sshcluster_spec, "test", "default", sshcluster_meta_with_owner, patch)
         assert patch["status"]["initialization"]["provisioned"] is True
         assert patch["status"]["ready"] is True
-        assert patch["status"]["conditions"][0]["status"] == "True"
-        assert patch["status"]["conditions"][0]["reason"] == "Provisioned"
+        conditions = _conditions_by_type(patch["status"])
+        assert conditions["Ready"]["status"] == "True"
+        assert conditions["Ready"]["reason"] == "Provisioned"
+        assert conditions["InfrastructureReady"]["status"] == "True"
+        assert conditions["ControlPlaneEndpointReady"]["status"] == "True"
 
     def test_invalid_endpoint_not_ready(self, sshcluster_meta_with_owner):
         spec = {"controlPlaneEndpoint": {"host": "", "port": 0}}
@@ -56,7 +66,10 @@ class TestSSHClusterReconcile:
         _reconcile(spec, "test", "default", sshcluster_meta_with_owner, patch)
         assert patch["status"]["initialization"]["provisioned"] is False
         assert patch["status"]["ready"] is False
-        assert patch["status"]["conditions"][0]["reason"] == "InvalidEndpoint"
+        conditions = _conditions_by_type(patch["status"])
+        assert conditions["Ready"]["reason"] == "InvalidEndpoint"
+        assert conditions["InfrastructureReady"]["status"] == "False"
+        assert conditions["ControlPlaneEndpointReady"]["status"] == "False"
 
     def test_idempotent_reconciliation(self, sshcluster_spec, sshcluster_meta_with_owner):
         """Running reconcile twice produces same result."""
@@ -69,5 +82,5 @@ class TestSSHClusterReconcile:
     def test_condition_has_timestamp(self, sshcluster_spec, sshcluster_meta_with_owner):
         patch = kopf.Patch({})
         _reconcile(sshcluster_spec, "test", "default", sshcluster_meta_with_owner, patch)
-        condition = patch["status"]["conditions"][0]
-        assert "lastTransitionTime" in condition
+        for condition in patch["status"]["conditions"]:
+            assert "lastTransitionTime" in condition

--- a/python/tests/test_sshmachine.py
+++ b/python/tests/test_sshmachine.py
@@ -37,6 +37,10 @@ from capi_provider_ssh.controllers.sshmachine import (
 from capi_provider_ssh.ssh import SSHResult
 
 
+def _conditions_by_type(status: dict) -> dict[str, dict]:
+    return {condition["type"]: condition for condition in status.get("conditions", [])}
+
+
 @pytest.fixture(autouse=True)
 def distributed_lock_success_for_handlers():
     """Keep existing reconcile/delete tests focused by defaulting distributed lock to success."""
@@ -296,7 +300,10 @@ class TestSSHMachineReconcile:
             patch=patch_obj,
         )
         assert patch_obj["status"]["initialization"]["provisioned"] is False
-        assert patch_obj["status"]["conditions"][0]["reason"] == "WaitingForMachineOwner"
+        conditions = _conditions_by_type(patch_obj["status"])
+        assert conditions["Ready"]["reason"] == "WaitingForMachineOwner"
+        assert conditions["InfrastructureReady"]["status"] == "False"
+        assert conditions["BootstrapExecSucceeded"]["status"] == "False"
 
     @pytest.mark.asyncio
     async def test_already_provisioned_skips(self, sshmachine_spec, sshmachine_meta_with_owner):
@@ -563,8 +570,11 @@ class TestSSHMachineReconcile:
         assert patch_obj["status"]["initialization"]["provisioned"] is False
         assert patch_obj["status"]["failureReason"] == "KubeletNotReady"
         assert "Bootstrap completed, but kubelet is not ready" in patch_obj["status"]["failureMessage"]
-        assert patch_obj["status"]["conditions"][0]["reason"] == "KubeletNotReady"
-        assert patch_obj["status"]["conditions"][1]["type"] == "Bootstrapped"
+        conditions = _conditions_by_type(patch_obj["status"])
+        assert conditions["Ready"]["reason"] == "KubeletNotReady"
+        assert conditions["InfrastructureReady"]["status"] == "False"
+        assert conditions["BootstrapExecSucceeded"]["status"] == "True"
+        assert conditions["Bootstrapped"]["type"] == "Bootstrapped"
 
     @pytest.mark.asyncio
     async def test_successful_bootstrap_with_cloud_config(self, sshmachine_spec, sshmachine_meta_with_owner):
@@ -631,7 +641,8 @@ runcmd:
             meta={},
             patch=waiting_patch,
         )
-        assert waiting_patch["status"]["conditions"][0]["reason"] == "WaitingForMachineOwner"
+        waiting_conditions = _conditions_by_type(waiting_patch["status"])
+        assert waiting_conditions["Ready"]["reason"] == "WaitingForMachineOwner"
 
         mock_conn = AsyncMock()
         mock_conn.execute.return_value = SSHResult(exit_code=0, stdout="ok", stderr="")
@@ -751,8 +762,10 @@ runcmd:
         read_bootstrap.assert_not_called()
         assert patch_obj["status"]["ready"] is True
         assert patch_obj["spec"]["providerID"] == "ssh://100.64.0.10"
-        assert patch_obj["status"]["conditions"][0]["type"] == "Ready"
-        assert patch_obj["status"]["conditions"][0]["status"] == "True"
+        conditions = _conditions_by_type(patch_obj["status"])
+        assert conditions["Ready"]["status"] == "True"
+        assert conditions["InfrastructureReady"]["status"] == "True"
+        assert conditions["BootstrapExecSucceeded"]["status"] == "True"
 
     @pytest.mark.asyncio
     async def test_timer_backfills_missing_providerid_and_ready_on_provisioned_machine(
@@ -1043,9 +1056,10 @@ class TestSSHMachineDryRun:
         # Should NOT have uploaded or executed anything
         mock_conn.upload.assert_not_called()
         mock_conn.execute.assert_not_called()
-        # Should NOT set providerID or provisioned
+        # Should NOT set providerID or mark machine provisioned
         assert "providerID" not in patch_obj.get("spec", {})
-        assert "initialization" not in patch_obj.get("status", {})
+        assert patch_obj["status"]["initialization"]["provisioned"] is False
+        assert patch_obj["status"]["ready"] is False
 
     @pytest.mark.asyncio
     async def test_dryrun_sets_condition(self, sshmachine_meta_with_owner):
@@ -1089,10 +1103,13 @@ class TestSSHMachineDryRun:
             )
 
         conditions = patch_obj["status"]["conditions"]
-        assert len(conditions) == 1
-        assert conditions[0]["type"] == "DryRunValidated"
-        assert conditions[0]["reason"] == "PreflightPassed"
-        assert "SSH to 100.64.0.10" in conditions[0]["message"]
+        assert len(conditions) == 4
+        by_type = _conditions_by_type(patch_obj["status"])
+        assert by_type["Ready"]["status"] == "False"
+        assert by_type["InfrastructureReady"]["status"] == "False"
+        assert by_type["BootstrapExecSucceeded"]["status"] == "False"
+        assert by_type["DryRunValidated"]["reason"] == "PreflightPassed"
+        assert "SSH to 100.64.0.10" in by_type["DryRunValidated"]["message"]
         assert patch_obj["status"]["failureReason"] is None
         assert patch_obj["status"]["failureMessage"] is None
 


### PR DESCRIPTION
## Summary
- add explicit lifecycle condition sets for SSHCluster and SSHMachine (Ready, InfrastructureReady, plus endpoint/bootstrap lifecycle conditions)
- emit those conditions consistently across success, waiting, failure, dry-run, and delete paths
- harden provisioned-state backfill to restore all required lifecycle conditions, not only Ready
- update unit tests to assert by condition type instead of list ordering

## Testing
- /Users/administrator/Documents/Programming/Insight/capi-provider-ssh/python/.venv/bin/ruff check capi_provider_ssh/controllers/sshcluster.py capi_provider_ssh/controllers/sshmachine.py tests/test_sshcluster.py tests/test_sshmachine.py
- /Users/administrator/Documents/Programming/Insight/capi-provider-ssh/python/.venv/bin/pytest

Fixes #204