### PR TITLE
Feat #203: add SSHClusterTemplate CRD for ClusterClass

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,58 @@ Target Hosts (any SSH-reachable server)
 | Kind | Purpose |
 |------|---------|
 | `SSHCluster` | Cluster-level infrastructure (control plane endpoint) |
+| `SSHClusterTemplate` | ClusterClass template for `SSHCluster` objects |
 | `SSHMachine` | Per-machine infrastructure (SSH address, credentials) |
 | `SSHMachineTemplate` | Template for MachineDeployments |
+
+### ClusterClass Template Example
+
+```yaml
+apiVersion: infrastructure.alpininsight.ai/v1beta1
+kind: SSHClusterTemplate
+metadata:
+  name: ssh-cluster-template
+  namespace: default
+spec:
+  template:
+    spec:
+      controlPlaneEndpoint:
+        host: 10.0.0.10
+        port: 6443
+---
+apiVersion: infrastructure.alpininsight.ai/v1beta1
+kind: SSHMachineTemplate
+metadata:
+  name: ssh-worker-template
+  namespace: default
+spec:
+  template:
+    spec:
+      hostSelector:
+        matchLabels:
+          role: worker
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: ClusterClass
+metadata:
+  name: ssh-clusterclass
+  namespace: default
+spec:
+  infrastructure:
+    ref:
+      apiVersion: infrastructure.alpininsight.ai/v1beta1
+      kind: SSHClusterTemplate
+      name: ssh-cluster-template
+  workers:
+    machineDeployments:
+      - class: default-worker
+        template:
+          infrastructure:
+            ref:
+              apiVersion: infrastructure.alpininsight.ai/v1beta1
+              kind: SSHMachineTemplate
+              name: ssh-worker-template
+```
 
 ## CAPI Contract
 

--- a/docs/rbac-requirements.md
+++ b/docs/rbac-requirements.md
@@ -14,7 +14,7 @@ The reference implementation is in
 
 | API Group | Resources | Verbs | Purpose |
 |-----------|-----------|-------|---------|
-| `infrastructure.alpininsight.ai` | sshclusters, sshhosts, sshmachines, sshmachinetemplates | get, list, watch, create, update, patch, delete | Reconcile owned resources |
+| `infrastructure.alpininsight.ai` | sshclusters, sshclustertemplates, sshhosts, sshmachines, sshmachinetemplates | get, list, watch, create, update, patch, delete | Reconcile owned resources |
 | `infrastructure.alpininsight.ai` | sshclusters/status, sshhosts/status, sshmachines/status | get, update, patch | Update status subresources |
 | `infrastructure.alpininsight.ai` | sshclusters/finalizers, sshmachines/finalizers | update | Manage cleanup finalizers |
 

--- a/python/deploy/rbac.yaml
+++ b/python/deploy/rbac.yaml
@@ -12,7 +12,7 @@ metadata:
 rules:
   # CRDs owned by this provider
   - apiGroups: ["infrastructure.alpininsight.ai"]
-    resources: ["sshclusters", "sshhosts", "sshmachines", "sshmachinetemplates"]
+    resources: ["sshclusters", "sshclustertemplates", "sshhosts", "sshmachines", "sshmachinetemplates"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["infrastructure.alpininsight.ai"]
     resources: ["sshclusters/status", "sshhosts/status", "sshmachines/status"]
@@ -65,7 +65,7 @@ metadata:
     cluster.x-k8s.io/aggregate-to-manager: "true"
 rules:
   - apiGroups: ["infrastructure.alpininsight.ai"]
-    resources: ["sshclusters", "sshhosts", "sshmachines", "sshmachinetemplates"]
+    resources: ["sshclusters", "sshclustertemplates", "sshhosts", "sshmachines", "sshmachinetemplates"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["infrastructure.alpininsight.ai"]
     resources: ["sshclusters/status", "sshhosts/status", "sshmachines/status"]
@@ -79,7 +79,7 @@ metadata:
     kubeadm.controlplane.cluster.x-k8s.io/aggregate-to-manager: "true"
 rules:
   - apiGroups: ["infrastructure.alpininsight.ai"]
-    resources: ["sshclusters", "sshhosts", "sshmachines", "sshmachinetemplates"]
+    resources: ["sshclusters", "sshclustertemplates", "sshhosts", "sshmachines", "sshmachinetemplates"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["infrastructure.alpininsight.ai"]
     resources: ["sshclusters/status", "sshhosts/status", "sshmachines/status"]

--- a/python/tests/test_crd_templates.py
+++ b/python/tests/test_crd_templates.py
@@ -1,0 +1,50 @@
+"""Tests for CRD template manifests."""
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CRD_DIR = REPO_ROOT / "shared" / "crds"
+
+
+def _load_yaml(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def test_sshclustertemplate_crd_schema_contract() -> None:
+    crd = _load_yaml(CRD_DIR / "sshclustertemplate.yaml")
+
+    assert crd["kind"] == "CustomResourceDefinition"
+    assert crd["metadata"]["name"] == "sshclustertemplates.infrastructure.alpininsight.ai"
+    assert crd["spec"]["names"]["kind"] == "SSHClusterTemplate"
+    assert crd["spec"]["names"]["plural"] == "sshclustertemplates"
+
+    schema = crd["spec"]["versions"][0]["schema"]["openAPIV3Schema"]
+    spec_schema = schema["properties"]["spec"]
+    assert "template" in spec_schema["required"]
+
+    template_schema = spec_schema["properties"]["template"]
+    assert "spec" in template_schema["required"]
+    template_spec = template_schema["properties"]["spec"]
+    assert "controlPlaneEndpoint" in template_spec["required"]
+
+    endpoint = template_spec["properties"]["controlPlaneEndpoint"]
+    assert sorted(endpoint["required"]) == ["host", "port"]
+
+
+def test_sshclustertemplate_template_spec_is_immutable() -> None:
+    crd = _load_yaml(CRD_DIR / "sshclustertemplate.yaml")
+    spec_schema = crd["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["spec"]
+    validations = spec_schema.get("x-kubernetes-validations", [])
+
+    assert any(v.get("rule") == "self.template.spec == oldSelf.template.spec" for v in validations), (
+        "SSHClusterTemplate must enforce spec.template.spec immutability."
+    )
+
+
+def test_crd_kustomization_includes_sshclustertemplate() -> None:
+    kustomization = _load_yaml(CRD_DIR / "kustomization.yaml")
+    resources = kustomization.get("resources", [])
+
+    assert "sshclustertemplate.yaml" in resources

--- a/shared/crds/kustomization.yaml
+++ b/shared/crds/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - sshcluster.yaml
+  - sshclustertemplate.yaml
   - sshhost.yaml
   - sshmachine.yaml
   - sshmachinetemplate.yaml

--- a/shared/crds/sshclustertemplate.yaml
+++ b/shared/crds/sshclustertemplate.yaml
@@ -1,0 +1,73 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: sshclustertemplates.infrastructure.alpininsight.ai
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-ssh
+    cluster.x-k8s.io/v1beta1: v1beta1
+spec:
+  group: infrastructure.alpininsight.ai
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - template
+              properties:
+                template:
+                  type: object
+                  required:
+                    - spec
+                  properties:
+                    metadata:
+                      type: object
+                      description: Metadata propagated to generated SSHCluster objects.
+                      properties:
+                        labels:
+                          type: object
+                          additionalProperties:
+                            type: string
+                        annotations:
+                          type: object
+                          additionalProperties:
+                            type: string
+                    spec:
+                      type: object
+                      required:
+                        - controlPlaneEndpoint
+                      properties:
+                        controlPlaneEndpoint:
+                          type: object
+                          required:
+                            - host
+                            - port
+                          properties:
+                            host:
+                              type: string
+                              description: Hostname or IP of the control plane endpoint.
+                            port:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                              description: Port of the control plane API server.
+                        paused:
+                          type: boolean
+                          description: Indicates the resource is paused and will not be reconciled.
+              x-kubernetes-validations:
+                - rule: self.template.spec == oldSelf.template.spec
+                  message: SSHClusterTemplate spec.template.spec is immutable
+  scope: Namespaced
+  names:
+    plural: sshclustertemplates
+    singular: sshclustertemplate
+    kind: SSHClusterTemplate
+    shortNames:
+      - sshct
+    categories:
+      - cluster-api


### PR DESCRIPTION
## Summary
- add new SSHClusterTemplate CRD (v1beta1) for ClusterClass infrastructure templates
- enforce template immutability with CRD validation (spec.template.spec immutable)
- include the new CRD in shared/crds/kustomization.yaml
- expand RBAC resource lists/docs to include sshclustertemplates
- add CRD manifest tests and README usage example for ClusterClass references

## Testing
- /Users/administrator/Documents/Programming/Insight/capi-provider-ssh/python/.venv/bin/ruff check .
- /Users/administrator/Documents/Programming/Insight/capi-provider-ssh/python/.venv/bin/pytest

Fixes #203