### PR TITLE
fix(ci): require auto-merge for changelog PRs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -112,14 +112,12 @@ jobs:
             echo "PR #$PR_NUM is $STATE; skipping merge."
             exit 0
           fi
-          # Use auto-merge: GitHub waits for required checks then merges.
-          # Falls back to direct merge for repos without required checks
-          # or where auto-merge is not enabled in repo settings.
-          if gh pr merge "$PR_NUM" --auto --squash --delete-branch 2>/dev/null; then
+          if gh pr merge "$PR_NUM" --auto --squash --delete-branch; then
             echo "Auto-merge enabled on PR #$PR_NUM. GitHub will merge when checks pass."
           else
-            echo "Auto-merge unavailable, attempting direct merge..."
-            gh pr merge "$PR_NUM" --squash --delete-branch
+            echo "::error::Could not enable auto-merge for PR #$PR_NUM."
+            echo "::error::Check repository auto-merge settings and token permissions."
+            exit 1
           fi
 
       - name: Summary


### PR DESCRIPTION
## Change
Enforce auto-merge for changelog PRs in `.github/workflows/changelog.yml`.

## Why
Changelog PRs should always use GitHub auto-merge. The previous fallback path performed a direct merge when `--auto` was unavailable.

## Behavior now
- tries `gh pr merge --auto --squash --delete-branch`
- if auto-merge cannot be enabled, workflow fails explicitly
