### PR TITLE
fix(runtime): declare Kopf cluster scope

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -27,4 +27,4 @@ LABEL org.opencontainers.image.vendor="Alpin Insight Solutions" \
       org.opencontainers.image.source="https://github.com/alpininsight/capi-provider-ssh" \
       org.opencontainers.image.description="Cluster API infrastructure provider for SSH-reachable hosts"
 
-ENTRYPOINT ["kopf", "run", "--standalone", "--liveness=http://0.0.0.0:8080/healthz", "-m", "capi_provider_ssh.main"]
+ENTRYPOINT ["kopf", "run", "--all-namespaces", "--standalone", "--liveness=http://0.0.0.0:8080/healthz", "-m", "capi_provider_ssh.main"]

--- a/python/tests/test_runtime_regression.py
+++ b/python/tests/test_runtime_regression.py
@@ -21,6 +21,9 @@ def test_docker_entrypoint_uses_kopf_directly() -> None:
         "Regression guard: ENTRYPOINT must not use `uv run` because it may write to `~/.cache/uv` at runtime."
     )
     assert '"kopf", "run"' in entrypoint, "ENTRYPOINT must execute kopf directly from the venv."
+    assert '"--all-namespaces"' in entrypoint, (
+        "Regression guard: the provider owns cluster-scoped CAPI resources, so Kopf scope must stay explicit."
+    )
     assert "--liveness=http://0.0.0.0:8080/healthz" in entrypoint, (
         "Regression guard: probes target /healthz on 8080, so Kopf liveness must be enabled in ENTRYPOINT."
     )


### PR DESCRIPTION
## Summary
- explicitly run the SSH provider in Kopf's cluster-wide mode
- preserve standalone operation and the existing liveness endpoint
- add a runtime regression for the required scope flag

## Production delivery
This is the narrow production hotfix equivalent of #223. `develop` is not promoted wholesale because it currently differs materially from `main`; this PR applies only the verified compatibility fix to the current stable provider line.

## Why
Kopf 1.43 emits a future-compatibility warning when neither namespaces nor cluster-wide scope is declared. The provider uses ClusterRole RBAC and handles CAPI resources cluster-wide, so `--all-namespaces` makes the existing intended operating scope explicit.

## Validation
- `uv run kopf run --help`
- `uv run pytest -q` (126 passed, 28 skipped)
- `uv run ruff check capi_provider_ssh tests`
- `uv run ruff format --check capi_provider_ssh tests`
- `kubectl kustomize python/deploy`