### PR TITLE
chore(release): promote develop to main

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -112,14 +112,12 @@ jobs:
             echo "PR #$PR_NUM is $STATE; skipping merge."
             exit 0
           fi
-          # Use auto-merge: GitHub waits for required checks then merges.
-          # Falls back to direct merge for repos without required checks
-          # or where auto-merge is not enabled in repo settings.
-          if gh pr merge "$PR_NUM" --auto --squash --delete-branch 2>/dev/null; then
+          if gh pr merge "$PR_NUM" --auto --squash --delete-branch; then
             echo "Auto-merge enabled on PR #$PR_NUM. GitHub will merge when checks pass."
           else
-            echo "Auto-merge unavailable, attempting direct merge..."
-            gh pr merge "$PR_NUM" --squash --delete-branch
+            echo "::error::Could not enable auto-merge for PR #$PR_NUM."
+            echo "::error::Check repository auto-merge settings and token permissions."
+            exit 1
           fi
 
       - name: Summary

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
           token: ${{ secrets.CHANGELOG_BOT_TOKEN != '' && secrets.CHANGELOG_BOT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Install git-cliff

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ concurrency:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   release:
@@ -101,3 +102,84 @@ jobs:
           echo "### Release v${{ steps.version.outputs.version }} created" >> "$GITHUB_STEP_SUMMARY"
           echo "- Tag: v${{ steps.version.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- Version is available via GitHub Releases and git tags" >> "$GITHUB_STEP_SUMMARY"
+
+  sync-main-to-develop:
+    name: Sync main back to develop
+    runs-on: ubuntu-latest
+    needs: release
+    if: github.ref_name == 'main' && needs.release.result == 'success'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.CHANGELOG_BOT_TOKEN != '' && secrets.CHANGELOG_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Create or update sync PR
+        id: sync_pr
+        env:
+          GH_TOKEN: ${{ secrets.CHANGELOG_BOT_TOKEN != '' && secrets.CHANGELOG_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin main develop
+          AHEAD_COUNT="$(git rev-list --count origin/develop..origin/main)"
+          if [ "${AHEAD_COUNT}" -eq 0 ]; then
+            echo "No commits to sync from main into develop."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          BRANCH="chore/sync-main-to-develop"
+          git checkout -B "${BRANCH}" origin/main
+          git push --force origin "${BRANCH}"
+
+          PR_NUM="$(gh pr list --state open --head "${BRANCH}" --base develop --json number --jq '.[0].number')"
+          if [ -n "${PR_NUM}" ] && [ "${PR_NUM}" != "null" ]; then
+            echo "Updating existing PR #${PR_NUM}"
+            gh pr edit "${PR_NUM}" \
+              --title "chore(sync): merge main back into develop" \
+              --body "Automated sync PR after a successful release on main."
+          else
+            echo "Creating new sync PR from ${BRANCH} to develop"
+            gh pr create \
+              --base develop \
+              --head "${BRANCH}" \
+              --title "chore(sync): merge main back into develop" \
+              --body "Automated sync PR after a successful release on main."
+            PR_NUM="$(gh pr list --state open --head "${BRANCH}" --base develop --json number --jq '.[0].number')"
+          fi
+
+          if [ -z "${PR_NUM}" ] || [ "${PR_NUM}" = "null" ]; then
+            echo "::error::Could not resolve sync PR number."
+            exit 1
+          fi
+
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "pr_number=${PR_NUM}" >> "$GITHUB_OUTPUT"
+
+      - name: Enable auto-merge on sync PR
+        if: steps.sync_pr.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CHANGELOG_BOT_TOKEN != '' && secrets.CHANGELOG_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          PR_NUM="${{ steps.sync_pr.outputs.pr_number }}"
+          if gh pr merge "${PR_NUM}" --auto --merge --delete-branch 2>/dev/null; then
+            echo "Auto-merge enabled on sync PR #${PR_NUM}."
+          else
+            echo "Auto-merge unavailable, attempting direct merge..."
+            gh pr merge "${PR_NUM}" --merge --delete-branch
+          fi
+
+      - name: Summary
+        env:
+          SYNC_CHANGED: ${{ steps.sync_pr.outputs.changed }}
+          SYNC_PR_NUMBER: ${{ steps.sync_pr.outputs.pr_number }}
+        run: |
+          echo "### Sync main -> develop" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Sync needed: ${SYNC_CHANGED:-false}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- PR: ${SYNC_PR_NUMBER:-n/a}" >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **sshmachine:** Keep ready in every provisioned reconcile patch
 - **sshmachine:** Inject kubelet provider-id into bootstrap
 - **ci:** Sync main back into develop after release 
+- **ci:** Enforce auto-merge for changelog PRs 
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ci:** Satisfy ruff line-length for #196
 - **sshmachine:** Keep ready in every provisioned reconcile patch
 - **sshmachine:** Inject kubelet provider-id into bootstrap
+- **ci:** Sync main back into develop after release 
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **sshmachine:** Inject kubelet provider-id into bootstrap
 - **ci:** Sync main back into develop after release 
 - **ci:** Enforce auto-merge for changelog PRs 
+- **runtime:** Declare Kopf cluster scope
 
 ### Documentation
 

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -27,4 +27,4 @@ LABEL org.opencontainers.image.vendor="Alpin Insight Solutions" \
       org.opencontainers.image.source="https://github.com/alpininsight/capi-provider-ssh" \
       org.opencontainers.image.description="Cluster API infrastructure provider for SSH-reachable hosts"
 
-ENTRYPOINT ["kopf", "run", "--standalone", "--liveness=http://0.0.0.0:8080/healthz", "-m", "capi_provider_ssh.main"]
+ENTRYPOINT ["kopf", "run", "--all-namespaces", "--standalone", "--liveness=http://0.0.0.0:8080/healthz", "-m", "capi_provider_ssh.main"]

--- a/python/tests/test_runtime_regression.py
+++ b/python/tests/test_runtime_regression.py
@@ -21,6 +21,9 @@ def test_docker_entrypoint_uses_kopf_directly() -> None:
         "Regression guard: ENTRYPOINT must not use `uv run` because it may write to `~/.cache/uv` at runtime."
     )
     assert '"kopf", "run"' in entrypoint, "ENTRYPOINT must execute kopf directly from the venv."
+    assert '"--all-namespaces"' in entrypoint, (
+        "Regression guard: the provider owns cluster-scoped CAPI resources, so Kopf scope must stay explicit."
+    )
     assert "--liveness=http://0.0.0.0:8080/healthz" in entrypoint, (
         "Regression guard: probes target /healthz on 8080, so Kopf liveness must be enabled in ENTRYPOINT."
     )


### PR DESCRIPTION
## Summary
- release the explicit Kopf `--all-namespaces` compatibility contract from #223
- include the already-merged changelog/release synchronization hardening on `develop`
- no controller logic, RBAC, CRDs, or GitOps manifests change in this promotion

## Delivery rationale
The repository policy permits `main` merges only from `develop`. A merge simulation is conflict-free; the release diff spans five files and is limited to the container entrypoint, its regression, changelog, and release/changelog automation.

## Validation
- source change #223: GitHub CI green
- local provider verification: `uv run pytest -q` (126 passed, 28 skipped)
- `uv run ruff check capi_provider_ssh tests`
- `uv run ruff format --check capi_provider_ssh tests`
- `kubectl kustomize python/deploy`
- release PR CI will revalidate the merged source target